### PR TITLE
added 'sync move' function and example and some formatting

### DIFF
--- a/examples/MoveSynchronously/MoveSynchronously.ino
+++ b/examples/MoveSynchronously/MoveSynchronously.ino
@@ -1,5 +1,4 @@
-// Basic example of making a STS3215 servos move async.
-//
+// Basic example of making a STS3215 servos move synchronously.
 // This code will simply make the two servos move from (180, 360)deg.
 
 #include "STSServoDriver.h"

--- a/examples/MoveSynchronously/MoveSynchronously.ino
+++ b/examples/MoveSynchronously/MoveSynchronously.ino
@@ -11,38 +11,38 @@ int speeds[] = {2400, 2400};
 
 void setup()
 {
-  pinMode(13, OUTPUT);
-  digitalWrite(13, LOW);
-  // Since the serial port is taken by the servo, we can't easily send debug messages, so
-  // we use the on-board led instead.
-  // Try to connect with the servos, using pin 2 as direction pin and the default (only) serial
-  // interface of an Arduino Uno.
-  if (!servos.init(2))
-  {
-    // Failed to get a ping reply, turn on the led.
-    digitalWrite(13, HIGH);
-  }
+    pinMode(13, OUTPUT);
+    digitalWrite(13, LOW);
+    // Since the serial port is taken by the servo, we can't easily send debug messages, so
+    // we use the on-board led instead.
+    // Try to connect with the servos, using pin 2 as direction pin and the default (only) serial
+    // interface of an Arduino Uno.
+    if (!servos.init(2))
+    {
+        // Failed to get a ping reply, turn on the led.
+        digitalWrite(13, HIGH);
+    }
 }
 
 void loop()
 {
-  // Move to 180deg.
-  positions[0] = 2048;
-  positions[1] = 2048;
-  servos.setTargetPositions(ids, positions, speeds);
-  // Wait for servo to start moving, then wait for end of motion
-  delay(100);
-  while (servos.isMoving(1))
-    delay(50);
-  // Wait a bit more to see it stop
-  delay(500);
+    // Move to 180deg.
+    positions[0] = 2048;
+    positions[1] = 2048;
+    servos.setTargetPositions(ids, positions, speeds);
+    // Wait for servo to start moving, then wait for end of motion
+    delay(100);
+    while (servos.isMoving(1))
+        delay(50);
+    // Wait a bit more to see it stop
+    delay(500);
 
-  // Move to 360deg.
-  positions[0] = 4095;
-  positions[1] = 4095;
-  servos.setTargetPositions(ids, positions, speeds);
-  delay(100);
-  while (servos.isMoving(1))
-    delay(50);
-  delay(500);
+    // Move to 360deg.
+    positions[0] = 4095;
+    positions[1] = 4095;
+    servos.setTargetPositions(ids, positions, speeds);
+    delay(100);
+    while (servos.isMoving(1))
+        delay(50);
+    delay(500);
 }

--- a/examples/SyncMove/SyncMove.ino
+++ b/examples/SyncMove/SyncMove.ino
@@ -6,24 +6,27 @@
 
 STSServoDriver servos;
 
-byte ids[] = { 1, 2 };
+byte ids[] = {1, 2};
 int positions[2];
-int speeds[] = { 2400, 2400 };
+int speeds[] = {2400, 2400};
 
-void setup() {
+void setup()
+{
   pinMode(13, OUTPUT);
   digitalWrite(13, LOW);
   // Since the serial port is taken by the servo, we can't easily send debug messages, so
   // we use the on-board led instead.
   // Try to connect with the servos, using pin 2 as direction pin and the default (only) serial
   // interface of an Arduino Uno.
-  if (!servos.init(2)) {
+  if (!servos.init(2))
+  {
     // Failed to get a ping reply, turn on the led.
     digitalWrite(13, HIGH);
   }
 }
 
-void loop() {
+void loop()
+{
   // Move to 180deg.
   positions[0] = 2048;
   positions[1] = 2048;

--- a/examples/SyncMove/SyncMove.ino
+++ b/examples/SyncMove/SyncMove.ino
@@ -1,0 +1,46 @@
+// Basic example of making a STS3215 servos move async.
+//
+// This code will simply make the two servos move from (180, 360)deg.
+
+#include "STSServoDriver.h"
+
+STSServoDriver servos;
+
+byte ids[] = { 1, 2 };
+int positions[2];
+int speeds[] = { 2400, 2400 };
+
+void setup() {
+  pinMode(13, OUTPUT);
+  digitalWrite(13, LOW);
+  // Since the serial port is taken by the servo, we can't easily send debug messages, so
+  // we use the on-board led instead.
+  // Try to connect with the servos, using pin 2 as direction pin and the default (only) serial
+  // interface of an Arduino Uno.
+  if (!servos.init(2)) {
+    // Failed to get a ping reply, turn on the led.
+    digitalWrite(13, HIGH);
+  }
+}
+
+void loop() {
+  // Move to 180deg.
+  positions[0] = 2048;
+  positions[1] = 2048;
+  servos.setTargetPositions(ids, positions, speeds);
+  // Wait for servo to start moving, then wait for end of motion
+  delay(100);
+  while (servos.isMoving(1))
+    delay(50);
+  // Wait a bit more to see it stop
+  delay(500);
+
+  // Move to 360deg.
+  positions[0] = 4095;
+  positions[1] = 4095;
+  servos.setTargetPositions(ids, positions, speeds);
+  delay(100);
+  while (servos.isMoving(1))
+    delay(50);
+  delay(500);
+}

--- a/src/STSServoDriver.cpp
+++ b/src/STSServoDriver.cpp
@@ -69,9 +69,17 @@ bool STSServoDriver::setId(byte const &oldServoId, byte const &newServoId)
 	return ping(newServoId);
 }
 
-bool STSServoDriver::setGoalAcceleration(byte const &servoId, byte const &acceleration)
+bool STSServoDriver::setPositionOffset(byte const &servoId, int const &positionOffset)
 {
-	return writeRegister(servoId, STSRegisters::TARGET_ACCELERATION, acceleration)
+	if (!writeRegister(servoId, STSRegisters::WRITE_LOCK, 0))
+		return false;
+	// Write new position offset
+	if (!writeTwoBytesRegister(servoId, STSRegisters::POSITION_CORRECTION, positionOffset))
+		return false;
+	// Lock EEPROM
+	if (!writeRegister(servoId, STSRegisters::WRITE_LOCK, 1))
+		return false;
+	return true;
 }
 
 int STSServoDriver::getCurrentPosition(byte const &servoId)
@@ -118,6 +126,11 @@ bool STSServoDriver::setTargetPosition(byte const &servoId, int const &position,
 bool STSServoDriver::setTargetVelocity(byte const &servoId, int const &velocity, bool const &asynchronous)
 {
 	return writeTwoBytesRegister(servoId, STSRegisters::RUNNING_SPEED, velocity, asynchronous);
+}
+
+bool STSServoDriver::setTargetAcceleration(byte const &servoId, byte const &acceleration, bool const &asynchronous)
+{
+	return writeRegister(servoId, STSRegisters::TARGET_ACCELERATION, acceleration, asynchronous)
 }
 
 bool STSServoDriver::trigerAction()

--- a/src/STSServoDriver.cpp
+++ b/src/STSServoDriver.cpp
@@ -98,9 +98,16 @@ bool STSServoDriver::isMoving(byte const &servoId)
     return result > 0;
 }
 
-bool STSServoDriver::setTargetPosition(byte const &servoId, int const &position, bool const &asynchronous)
+bool STSServoDriver::setTargetPosition(byte const &servoId, int const &position, int const &speed, bool const &asynchronous)
 {
-    return writeTwoBytesRegister(servoId, STSRegisters::TARGET_POSITION, position, asynchronous);
+    byte params[6] = {
+        static_cast<unsigned char>(position & 0xFF),
+        static_cast<unsigned char>((position >> 8) & 0xFF),
+        0,
+        0,
+        static_cast<unsigned char>(speed & 0xFF),
+        static_cast<unsigned char>((speed >> 8) & 0xFF)};
+    return writeRegisters(servoId, STSRegisters::TARGET_POSITION, sizeof(params), params, asynchronous);
 }
 
 bool STSServoDriver::setTargetVelocity(byte const &servoId, int const &velocity, bool const &asynchronous)

--- a/src/STSServoDriver.cpp
+++ b/src/STSServoDriver.cpp
@@ -2,13 +2,13 @@
 
 namespace instruction
 {
-  byte const PING       = 0x01;
-  byte const READ       = 0x02;
-  byte const WRITE      = 0x03;
-  byte const REGWRITE   = 0x04;
-  byte const ACTION     = 0x05;
-  byte const SYNCWRITE  = 0x83;
-  byte const RESET      = 0x06;
+    byte const PING       = 0x01;
+    byte const READ       = 0x02;
+    byte const WRITE      = 0x03;
+    byte const REGWRITE   = 0x04;
+    byte const ACTION     = 0x05;
+    byte const SYNCWRITE  = 0x83;
+    byte const RESET      = 0x06;
 };
 
 STSServoDriver::STSServoDriver() : dirPin_(0)
@@ -18,126 +18,126 @@ STSServoDriver::STSServoDriver() : dirPin_(0)
 bool STSServoDriver::init(byte const &dirPin, HardwareSerial *serialPort, long const &baudRate)
 {
 #ifdef SERIAL_H
-  if (serialPort == nullptr)
-    serialPort = &Serial;
+    if (serialPort == nullptr)
+        serialPort = &Serial;
 #endif
-  // Open port
-  port_ = serialPort;
-  port_->begin(baudRate);
-  dirPin_ = dirPin;
-  pinMode(dirPin_, OUTPUT);
+    // Open port
+    port_ = serialPort;
+    port_->begin(baudRate);
+    dirPin_ = dirPin;
+    pinMode(dirPin_, OUTPUT);
 
-  // Test that a servo is present.
-  for (byte i = 0; i < 0xFE; i++)
-    if (ping(i))
-      return true;
-  return false;
+    // Test that a servo is present.
+    for (byte i = 0; i < 0xFE; i++)
+        if (ping(i))
+            return true;
+    return false;
 }
 
 bool STSServoDriver::ping(byte const &servoId)
 {
-  byte response[1] = {0xFF};
-  int send = sendMessage(servoId,
-                         instruction::PING,
-                         0,
-                         response);
-  // Failed to send
-  if (send != 6)
-    return false;
-  // Read response
-  int rd = recieveMessage(servoId, 1, response);
-  if (rd < 0)
-    return false;
-  return response[0] == 0x00;
+    byte response[1] = {0xFF};
+    int send = sendMessage(servoId,
+                           instruction::PING,
+                           0,
+                           response);
+    // Failed to send
+    if (send != 6)
+        return false;
+    // Read response
+    int rd = recieveMessage(servoId, 1, response);
+    if (rd < 0)
+        return false;
+    return response[0] == 0x00;
 }
 
 bool STSServoDriver::setId(byte const &oldServoId, byte const &newServoId)
 {
-  if (oldServoId >= 0xFE || newServoId >= 0xFE)
-    return false;
-  if (ping(newServoId))
-    return false; // address taken
-  // Unlock EEPROM
-  if (!writeRegister(oldServoId, STSRegisters::WRITE_LOCK, 0))
-    return false;
-  // Write new ID
-  if (!writeRegister(oldServoId, STSRegisters::ID, newServoId))
-    return false;
-  // Lock EEPROM
-  if (!writeRegister(newServoId, STSRegisters::WRITE_LOCK, 1))
-    return false;
-  return ping(newServoId);
+    if (oldServoId >= 0xFE || newServoId >= 0xFE)
+        return false;
+    if (ping(newServoId))
+        return false; // address taken
+    // Unlock EEPROM
+    if (!writeRegister(oldServoId, STSRegisters::WRITE_LOCK, 0))
+        return false;
+    // Write new ID
+    if (!writeRegister(oldServoId, STSRegisters::ID, newServoId))
+        return false;
+    // Lock EEPROM
+    if (!writeRegister(newServoId, STSRegisters::WRITE_LOCK, 1))
+        return false;
+    return ping(newServoId);
 }
 
 bool STSServoDriver::setPositionOffset(byte const &servoId, int const &positionOffset)
 {
-  if (!writeRegister(servoId, STSRegisters::WRITE_LOCK, 0))
-    return false;
-  // Write new position offset
-  if (!writeTwoBytesRegister(servoId, STSRegisters::POSITION_CORRECTION, positionOffset))
-    return false;
-  // Lock EEPROM
-  if (!writeRegister(servoId, STSRegisters::WRITE_LOCK, 1))
-    return false;
-  return true;
+    if (!writeRegister(servoId, STSRegisters::WRITE_LOCK, 0))
+        return false;
+    // Write new position offset
+    if (!writeTwoBytesRegister(servoId, STSRegisters::POSITION_CORRECTION, positionOffset))
+        return false;
+    // Lock EEPROM
+    if (!writeRegister(servoId, STSRegisters::WRITE_LOCK, 1))
+        return false;
+    return true;
 }
 
 int STSServoDriver::getCurrentPosition(byte const &servoId)
 {
-  int16_t pos = readTwoBytesRegister(servoId, STSRegisters::CURRENT_POSITION);
-  return pos;
+    int16_t pos = readTwoBytesRegister(servoId, STSRegisters::CURRENT_POSITION);
+    return pos;
 }
 
 int STSServoDriver::getCurrentSpeed(byte const &servoId)
 {
-  int16_t vel = readTwoBytesRegister(servoId, STSRegisters::CURRENT_SPEED);
-  return vel;
+    int16_t vel = readTwoBytesRegister(servoId, STSRegisters::CURRENT_SPEED);
+    return vel;
 }
 
 int STSServoDriver::getCurrentTemperature(byte const &servoId)
 {
-  return readTwoBytesRegister(servoId, STSRegisters::CURRENT_TEMPERATURE);
+    return readTwoBytesRegister(servoId, STSRegisters::CURRENT_TEMPERATURE);
 }
 
 int STSServoDriver::getCurrentCurrent(byte const &servoId)
 {
-  int16_t current = readTwoBytesRegister(servoId, STSRegisters::CURRENT_CURRENT);
-  return current * 0.0065;
+    int16_t current = readTwoBytesRegister(servoId, STSRegisters::CURRENT_CURRENT);
+    return current * 0.0065;
 }
 
 bool STSServoDriver::isMoving(byte const &servoId)
 {
-  byte const result = readRegister(servoId, STSRegisters::MOVING_STATUS);
-  return result > 0;
+    byte const result = readRegister(servoId, STSRegisters::MOVING_STATUS);
+    return result > 0;
 }
 
 bool STSServoDriver::setTargetPosition(byte const &servoId, int const &position, int const &speed, bool const &asynchronous)
 {
-  byte params[6] = {
-      static_cast<unsigned char>(position & 0xFF),
-      static_cast<unsigned char>((position >> 8) & 0xFF),
-      0,
-      0,
-      static_cast<unsigned char>(speed & 0xFF),
-      static_cast<unsigned char>((speed >> 8) & 0xFF)};
-  return writeRegisters(servoId, STSRegisters::TARGET_POSITION, sizeof(params), params, asynchronous);
+    byte params[6] = {
+        static_cast<unsigned char>(position & 0xFF),
+        static_cast<unsigned char>((position >> 8) & 0xFF),
+        0,
+        0,
+        static_cast<unsigned char>(speed & 0xFF),
+        static_cast<unsigned char>((speed >> 8) & 0xFF)};
+    return writeRegisters(servoId, STSRegisters::TARGET_POSITION, sizeof(params), params, asynchronous);
 }
 
 bool STSServoDriver::setTargetVelocity(byte const &servoId, int const &velocity, bool const &asynchronous)
 {
-  return writeTwoBytesRegister(servoId, STSRegisters::RUNNING_SPEED, velocity, asynchronous);
+    return writeTwoBytesRegister(servoId, STSRegisters::RUNNING_SPEED, velocity, asynchronous);
 }
 
 bool STSServoDriver::setTargetAcceleration(byte const &servoId, byte const &acceleration, bool const &asynchronous)
 {
-  return writeRegister(servoId, STSRegisters::TARGET_ACCELERATION, acceleration, asynchronous);
+    return writeRegister(servoId, STSRegisters::TARGET_ACCELERATION, acceleration, asynchronous);
 }
 
 bool STSServoDriver::trigerAction()
 {
-  byte noParam = 0;
-  int send = sendMessage(0xFE, instruction::ACTION, 0, &noParam);
-  return send == 6;
+    byte noParam = 0;
+    int send = sendMessage(0xFE, instruction::ACTION, 0, &noParam);
+    return send == 6;
 }
 
 int STSServoDriver::sendMessage(byte const &servoId,
@@ -145,26 +145,26 @@ int STSServoDriver::sendMessage(byte const &servoId,
                                 byte const &paramLength,
                                 byte *parameters)
 {
-  byte message[6 + paramLength];
-  byte checksum = servoId + paramLength + 2 + commandID;
-  message[0] = 0xFF;
-  message[1] = 0xFF;
-  message[2] = servoId;
-  message[3] = paramLength + 2;
-  message[4] = commandID;
-  for (int i = 0; i < paramLength; i++)
-  {
-    message[5 + i] = parameters[i];
-    checksum += parameters[i];
-  }
-  message[5 + paramLength] = ~checksum;
+    byte message[6 + paramLength];
+    byte checksum = servoId + paramLength + 2 + commandID;
+    message[0] = 0xFF;
+    message[1] = 0xFF;
+    message[2] = servoId;
+    message[3] = paramLength + 2;
+    message[4] = commandID;
+    for (int i = 0; i < paramLength; i++)
+    {
+        message[5 + i] = parameters[i];
+        checksum += parameters[i];
+    }
+    message[5 + paramLength] = ~checksum;
 
-  digitalWrite(dirPin_, HIGH);
-  int ret = port_->write(message, 6 + paramLength);
-  digitalWrite(dirPin_, LOW);
-  // Give time for the message to be processed.
-  delayMicroseconds(200);
-  return ret;
+    digitalWrite(dirPin_, HIGH);
+    int ret = port_->write(message, 6 + paramLength);
+    digitalWrite(dirPin_, LOW);
+    // Give time for the message to be processed.
+    delayMicroseconds(200);
+    return ret;
 }
 
 bool STSServoDriver::writeRegisters(byte const &servoId,
@@ -173,15 +173,15 @@ bool STSServoDriver::writeRegisters(byte const &servoId,
                                     byte const *parameters,
                                     bool const &asynchronous)
 {
-  byte param[writeLength + 1];
-  param[0] = startRegister;
-  for (int i = 0; i < writeLength; i++)
-    param[i + 1] = parameters[i];
-  int rc = sendMessage(servoId,
-                       asynchronous ? instruction::REGWRITE : instruction::WRITE,
-                       writeLength + 1,
-                       param);
-  return rc == writeLength + 7;
+    byte param[writeLength + 1];
+    param[0] = startRegister;
+    for (int i = 0; i < writeLength; i++)
+        param[i + 1] = parameters[i];
+    int rc = sendMessage(servoId,
+                         asynchronous ? instruction::REGWRITE : instruction::WRITE,
+                         writeLength + 1,
+                         param);
+    return rc == writeLength + 7;
 }
 
 bool STSServoDriver::writeRegister(byte const &servoId,
@@ -189,7 +189,7 @@ bool STSServoDriver::writeRegister(byte const &servoId,
                                    byte const &value,
                                    bool const &asynchronous)
 {
-  return writeRegisters(servoId, registerId, 1, &value, asynchronous);
+    return writeRegisters(servoId, registerId, 1, &value, asynchronous);
 }
 
 bool STSServoDriver::writeTwoBytesRegister(byte const &servoId,
@@ -197,27 +197,27 @@ bool STSServoDriver::writeTwoBytesRegister(byte const &servoId,
                                            int16_t const &value,
                                            bool const &asynchronous)
 {
-  byte params[2] = {static_cast<unsigned char>(value & 0xFF),
-                    static_cast<unsigned char>((value >> 8) & 0xFF)};
-  return writeRegisters(servoId, registerId, 2, params, asynchronous);
+    byte params[2] = {static_cast<unsigned char>(value & 0xFF),
+                      static_cast<unsigned char>((value >> 8) & 0xFF)};
+    return writeRegisters(servoId, registerId, 2, params, asynchronous);
 }
 
 byte STSServoDriver::readRegister(byte const &servoId, byte const &registerId)
 {
-  byte result = 0;
-  int rc = readRegisters(servoId, registerId, 1, &result);
-  if (rc < 0)
-    return 0;
-  return result;
+    byte result = 0;
+    int rc = readRegisters(servoId, registerId, 1, &result);
+    if (rc < 0)
+        return 0;
+    return result;
 }
 
 int16_t STSServoDriver::readTwoBytesRegister(byte const &servoId, byte const &registerId)
 {
-  byte result[2] = {0, 0};
-  int rc = readRegisters(servoId, registerId, 2, result);
-  if (rc < 0)
-    return 0;
-  return result[0] + (result[1] << 8);
+    byte result[2] = {0, 0};
+    int rc = readRegisters(servoId, registerId, 2, result);
+    if (rc < 0)
+        return 0;
+    return result[0] + (result[1] << 8);
 }
 
 int STSServoDriver::readRegisters(byte const &servoId,
@@ -225,86 +225,86 @@ int STSServoDriver::readRegisters(byte const &servoId,
                                   byte const &readLength,
                                   byte *outputBuffer)
 {
-  byte readParam[2] = {startRegister, readLength};
-  // Flush
-  while (port_->read() != -1)
+    byte readParam[2] = {startRegister, readLength};
+    // Flush
+    while (port_->read() != -1)
+        ;
     ;
-  ;
-  int send = sendMessage(servoId, instruction::READ, 2, readParam);
-  // Failed to send
-  if (send != 8)
-    return -1;
-  // Read
-  byte result[readLength + 1];
-  int rd = recieveMessage(servoId, readLength + 1, result);
-  if (rd < 0)
-    return rd;
+    int send = sendMessage(servoId, instruction::READ, 2, readParam);
+    // Failed to send
+    if (send != 8)
+        return -1;
+    // Read
+    byte result[readLength + 1];
+    int rd = recieveMessage(servoId, readLength + 1, result);
+    if (rd < 0)
+        return rd;
 
-  for (int i = 0; i < readLength; i++)
-    outputBuffer[i] = result[i + 1];
-  return 0;
+    for (int i = 0; i < readLength; i++)
+        outputBuffer[i] = result[i + 1];
+    return 0;
 }
 
 int STSServoDriver::recieveMessage(byte const &servoId,
                                    byte const &readLength,
                                    byte *outputBuffer)
 {
-  digitalWrite(dirPin_, LOW);
-  byte result[readLength + 5];
-  size_t rd = port_->readBytes(result, readLength + 5);
-  if (rd != (unsigned short)(readLength + 5))
-    return -1;
-  // Check message integrity
-  if (result[0] != 0xFF || result[1] != 0xFF || result[2] != servoId || result[3] != readLength + 1)
-    return -2;
-  byte checksum = 0;
-  for (int i = 2; i < readLength + 4; i++)
-    checksum += result[i];
-  checksum = ~checksum;
-  if (result[readLength + 4] != checksum)
-    return -3;
+    digitalWrite(dirPin_, LOW);
+    byte result[readLength + 5];
+    size_t rd = port_->readBytes(result, readLength + 5);
+    if (rd != (unsigned short)(readLength + 5))
+        return -1;
+    // Check message integrity
+    if (result[0] != 0xFF || result[1] != 0xFF || result[2] != servoId || result[3] != readLength + 1)
+        return -2;
+    byte checksum = 0;
+    for (int i = 2; i < readLength + 4; i++)
+        checksum += result[i];
+    checksum = ~checksum;
+    if (result[readLength + 4] != checksum)
+        return -3;
 
-  // Copy result to output buffer
-  for (int i = 0; i < readLength; i++)
-    outputBuffer[i] = result[i + 4];
-  return 0;
+    // Copy result to output buffer
+    for (int i = 0; i < readLength; i++)
+        outputBuffer[i] = result[i + 4];
+    return 0;
 }
 
 void STSServoDriver::convertIntToBytes(int const &value, byte result[2])
 {
-  result[0] = value & 0xFF;
-  result[1] = (value >> 8) & 0xFF;
+    result[0] = value & 0xFF;
+    result[1] = (value >> 8) & 0xFF;
 }
 
 void STSServoDriver::sendAndUpdateChecksum(byte convertedValue[], byte &checksum)
 {
-  port_->write(convertedValue, 2);
-  checksum += convertedValue[0] + convertedValue[1];
+    port_->write(convertedValue, 2);
+    checksum += convertedValue[0] + convertedValue[1];
 }
 
 void STSServoDriver::setTargetPositions(byte const &NumberOfServos, const byte servoIds[],
                                         const int positions[],
                                         const int speeds[])
 {
-  port_->write(0xFF);
-  port_->write(0xFF);
-  port_->write(0XFE);
-  port_->write(NumberOfServos * 7 + 4);
-  port_->write(instruction::SYNCWRITE);
-  port_->write(STSRegisters::TARGET_POSITION);
-  port_->write(6);
-  byte checksum = 0xFE + NumberOfServos * 7 + 4 + instruction::SYNCWRITE + STSRegisters::TARGET_POSITION + 6;
-  for (int index = 0; index < NumberOfServos; index++)
-  {
-    checksum += servoIds[index];
-    port_->write(servoIds[index]);
-    byte intAsByte[2];
-    convertIntToBytes(positions[index], intAsByte);
-    sendAndUpdateChecksum(intAsByte, checksum);
-    port_->write(0);
-    port_->write(0);
-    convertIntToBytes(speeds[index], intAsByte);
-    sendAndUpdateChecksum(intAsByte, checksum);
-  }
-  port_->write(~checksum);
+    port_->write(0xFF);
+    port_->write(0xFF);
+    port_->write(0XFE);
+    port_->write(NumberOfServos * 7 + 4);
+    port_->write(instruction::SYNCWRITE);
+    port_->write(STSRegisters::TARGET_POSITION);
+    port_->write(6);
+    byte checksum = 0xFE + NumberOfServos * 7 + 4 + instruction::SYNCWRITE + STSRegisters::TARGET_POSITION + 6;
+    for (int index = 0; index < NumberOfServos; index++)
+    {
+        checksum += servoIds[index];
+        port_->write(servoIds[index]);
+        byte intAsByte[2];
+        convertIntToBytes(positions[index], intAsByte);
+        sendAndUpdateChecksum(intAsByte, checksum);
+        port_->write(0);
+        port_->write(0);
+        convertIntToBytes(speeds[index], intAsByte);
+        sendAndUpdateChecksum(intAsByte, checksum);
+    }
+    port_->write(~checksum);
 }

--- a/src/STSServoDriver.cpp
+++ b/src/STSServoDriver.cpp
@@ -2,13 +2,13 @@
 
 namespace instruction
 {
-    byte const PING = 0x01;
-    byte const READ = 0x02;
-    byte const WRITE = 0x03;
-    byte const REGWRITE = 0x04;
-    byte const ACTION = 0x05;
-    byte const SYNCWRITE = 0x83;
-    byte const RESET = 0x06;
+	byte const PING = 0x01;
+	byte const READ = 0x02;
+	byte const WRITE = 0x03;
+	byte const REGWRITE = 0x04;
+	byte const ACTION = 0x05;
+	byte const SYNCWRITE = 0x83;
+	byte const RESET = 0x06;
 };
 
 STSServoDriver::STSServoDriver() : dirPin_(0)
@@ -18,275 +18,275 @@ STSServoDriver::STSServoDriver() : dirPin_(0)
 bool STSServoDriver::init(byte const &dirPin, HardwareSerial *serialPort, long const &baudRate)
 {
 #ifdef SERIAL_H
-    if (serialPort == nullptr)
-        serialPort = &Serial;
+	if (serialPort == nullptr)
+		serialPort = &Serial;
 #endif
-    // Open port
-    port_ = serialPort;
-    port_->begin(baudRate);
-    dirPin_ = dirPin;
-    pinMode(dirPin_, OUTPUT);
+	// Open port
+	port_ = serialPort;
+	port_->begin(baudRate);
+	dirPin_ = dirPin;
+	pinMode(dirPin_, OUTPUT);
 
-    // Test that a servo is present.
-    for (byte i = 0; i < 0xFE; i++)
-        if (ping(i))
-            return true;
-    return false;
+	// Test that a servo is present.
+	for (byte i = 0; i < 0xFE; i++)
+		if (ping(i))
+			return true;
+	return false;
 }
 
 bool STSServoDriver::ping(byte const &servoId)
 {
-    byte response[1] = {0xFF};
-    int send = sendMessage(servoId,
-                           instruction::PING,
-                           0,
-                           response);
-    // Failed to send
-    if (send != 6)
-        return false;
-    // Read response
-    int rd = recieveMessage(servoId, 1, response);
-    if (rd < 0)
-        return false;
-    return response[0] == 0x00;
+	byte response[1] = {0xFF};
+	int send = sendMessage(servoId,
+						   instruction::PING,
+						   0,
+						   response);
+	// Failed to send
+	if (send != 6)
+		return false;
+	// Read response
+	int rd = recieveMessage(servoId, 1, response);
+	if (rd < 0)
+		return false;
+	return response[0] == 0x00;
 }
 
 bool STSServoDriver::setId(byte const &oldServoId, byte const &newServoId)
 {
-    if (oldServoId >= 0xFE || newServoId >= 0xFE)
-        return false;
-    if (ping(newServoId))
-        return false; // address taken
-    // Unlock EEPROM
-    if (!writeRegister(oldServoId, STSRegisters::WRITE_LOCK, 0))
-        return false;
-    // Write new ID
-    if (!writeRegister(oldServoId, STSRegisters::ID, newServoId))
-        return false;
-    // Lock EEPROM
-    if (!writeRegister(newServoId, STSRegisters::WRITE_LOCK, 1))
-        return false;
-    return ping(newServoId);
+	if (oldServoId >= 0xFE || newServoId >= 0xFE)
+		return false;
+	if (ping(newServoId))
+		return false; // address taken
+	// Unlock EEPROM
+	if (!writeRegister(oldServoId, STSRegisters::WRITE_LOCK, 0))
+		return false;
+	// Write new ID
+	if (!writeRegister(oldServoId, STSRegisters::ID, newServoId))
+		return false;
+	// Lock EEPROM
+	if (!writeRegister(newServoId, STSRegisters::WRITE_LOCK, 1))
+		return false;
+	return ping(newServoId);
 }
 
 int STSServoDriver::getCurrentPosition(byte const &servoId)
 {
-    int16_t pos = readTwoBytesRegister(servoId, STSRegisters::CURRENT_POSITION);
-    return pos;
+	int16_t pos = readTwoBytesRegister(servoId, STSRegisters::CURRENT_POSITION);
+	return pos;
 }
 
 int STSServoDriver::getCurrentSpeed(byte const &servoId)
 {
-    int16_t vel = readTwoBytesRegister(servoId, STSRegisters::CURRENT_SPEED);
-    return vel;
+	int16_t vel = readTwoBytesRegister(servoId, STSRegisters::CURRENT_SPEED);
+	return vel;
 }
 
 int STSServoDriver::getCurrentTemperature(byte const &servoId)
 {
-    return readTwoBytesRegister(servoId, STSRegisters::CURRENT_TEMPERATURE);
+	return readTwoBytesRegister(servoId, STSRegisters::CURRENT_TEMPERATURE);
 }
 
 int STSServoDriver::getCurrentCurrent(byte const &servoId)
 {
-    int16_t current = readTwoBytesRegister(servoId, STSRegisters::CURRENT_CURRENT);
-    return current * 0.0065;
+	int16_t current = readTwoBytesRegister(servoId, STSRegisters::CURRENT_CURRENT);
+	return current * 0.0065;
 }
 
 bool STSServoDriver::isMoving(byte const &servoId)
 {
-    byte const result = readRegister(servoId, STSRegisters::MOVING_STATUS);
-    return result > 0;
+	byte const result = readRegister(servoId, STSRegisters::MOVING_STATUS);
+	return result > 0;
 }
 
 bool STSServoDriver::setTargetPosition(byte const &servoId, int const &position, int const &speed, bool const &asynchronous)
 {
-    byte params[6] = {
-        static_cast<unsigned char>(position & 0xFF),
-        static_cast<unsigned char>((position >> 8) & 0xFF),
-        0,
-        0,
-        static_cast<unsigned char>(speed & 0xFF),
-        static_cast<unsigned char>((speed >> 8) & 0xFF)};
-    return writeRegisters(servoId, STSRegisters::TARGET_POSITION, sizeof(params), params, asynchronous);
+	byte params[6] = {
+		static_cast<unsigned char>(position & 0xFF),
+		static_cast<unsigned char>((position >> 8) & 0xFF),
+		0,
+		0,
+		static_cast<unsigned char>(speed & 0xFF),
+		static_cast<unsigned char>((speed >> 8) & 0xFF)};
+	return writeRegisters(servoId, STSRegisters::TARGET_POSITION, sizeof(params), params, asynchronous);
 }
 
 bool STSServoDriver::setTargetVelocity(byte const &servoId, int const &velocity, bool const &asynchronous)
 {
-    return writeTwoBytesRegister(servoId, STSRegisters::RUNNING_SPEED, velocity, asynchronous);
+	return writeTwoBytesRegister(servoId, STSRegisters::RUNNING_SPEED, velocity, asynchronous);
 }
 
 bool STSServoDriver::trigerAction()
 {
-    byte noParam = 0;
-    int send = sendMessage(0xFE, instruction::ACTION, 0, &noParam);
-    return send == 6;
+	byte noParam = 0;
+	int send = sendMessage(0xFE, instruction::ACTION, 0, &noParam);
+	return send == 6;
 }
 
 int STSServoDriver::sendMessage(byte const &servoId,
-                                byte const &commandID,
-                                byte const &paramLength,
-                                byte *parameters)
+								byte const &commandID,
+								byte const &paramLength,
+								byte *parameters)
 {
-    byte message[6 + paramLength];
-    byte checksum = servoId + paramLength + 2 + commandID;
-    message[0] = 0xFF;
-    message[1] = 0xFF;
-    message[2] = servoId;
-    message[3] = paramLength + 2;
-    message[4] = commandID;
-    for (int i = 0; i < paramLength; i++)
-    {
-        message[5 + i] = parameters[i];
-        checksum += parameters[i];
-    }
-    message[5 + paramLength] = ~checksum;
+	byte message[6 + paramLength];
+	byte checksum = servoId + paramLength + 2 + commandID;
+	message[0] = 0xFF;
+	message[1] = 0xFF;
+	message[2] = servoId;
+	message[3] = paramLength + 2;
+	message[4] = commandID;
+	for (int i = 0; i < paramLength; i++)
+	{
+		message[5 + i] = parameters[i];
+		checksum += parameters[i];
+	}
+	message[5 + paramLength] = ~checksum;
 
-    digitalWrite(dirPin_, HIGH);
-    int ret = port_->write(message, 6 + paramLength);
-    digitalWrite(dirPin_, LOW);
-    // Give time for the message to be processed.
-    delayMicroseconds(200);
-    return ret;
+	digitalWrite(dirPin_, HIGH);
+	int ret = port_->write(message, 6 + paramLength);
+	digitalWrite(dirPin_, LOW);
+	// Give time for the message to be processed.
+	delayMicroseconds(200);
+	return ret;
 }
 
 bool STSServoDriver::writeRegisters(byte const &servoId,
-                                    byte const &startRegister,
-                                    byte const &writeLength,
-                                    byte const *parameters,
-                                    bool const &asynchronous)
+									byte const &startRegister,
+									byte const &writeLength,
+									byte const *parameters,
+									bool const &asynchronous)
 {
-    byte param[writeLength + 1];
-    param[0] = startRegister;
-    for (int i = 0; i < writeLength; i++)
-        param[i + 1] = parameters[i];
-    int rc = sendMessage(servoId,
-                         asynchronous ? instruction::REGWRITE : instruction::WRITE,
-                         writeLength + 1,
-                         param);
-    return rc == writeLength + 7;
+	byte param[writeLength + 1];
+	param[0] = startRegister;
+	for (int i = 0; i < writeLength; i++)
+		param[i + 1] = parameters[i];
+	int rc = sendMessage(servoId,
+						 asynchronous ? instruction::REGWRITE : instruction::WRITE,
+						 writeLength + 1,
+						 param);
+	return rc == writeLength + 7;
 }
 
 bool STSServoDriver::writeRegister(byte const &servoId,
-                                   byte const &registerId,
-                                   byte const &value,
-                                   bool const &asynchronous)
+								   byte const &registerId,
+								   byte const &value,
+								   bool const &asynchronous)
 {
-    return writeRegisters(servoId, registerId, 1, &value, asynchronous);
+	return writeRegisters(servoId, registerId, 1, &value, asynchronous);
 }
 
 bool STSServoDriver::writeTwoBytesRegister(byte const &servoId,
-                                           byte const &registerId,
-                                           int16_t const &value,
-                                           bool const &asynchronous)
+										   byte const &registerId,
+										   int16_t const &value,
+										   bool const &asynchronous)
 {
-    byte params[2] = {static_cast<unsigned char>(value & 0xFF),
-                      static_cast<unsigned char>((value >> 8) & 0xFF)};
-    return writeRegisters(servoId, registerId, 2, params, asynchronous);
+	byte params[2] = {static_cast<unsigned char>(value & 0xFF),
+					  static_cast<unsigned char>((value >> 8) & 0xFF)};
+	return writeRegisters(servoId, registerId, 2, params, asynchronous);
 }
 
 byte STSServoDriver::readRegister(byte const &servoId, byte const &registerId)
 {
-    byte result = 0;
-    int rc = readRegisters(servoId, registerId, 1, &result);
-    if (rc < 0)
-        return 0;
-    return result;
+	byte result = 0;
+	int rc = readRegisters(servoId, registerId, 1, &result);
+	if (rc < 0)
+		return 0;
+	return result;
 }
 
 int16_t STSServoDriver::readTwoBytesRegister(byte const &servoId, byte const &registerId)
 {
-    byte result[2] = {0, 0};
-    int rc = readRegisters(servoId, registerId, 2, result);
-    if (rc < 0)
-        return 0;
-    return result[0] + (result[1] << 8);
+	byte result[2] = {0, 0};
+	int rc = readRegisters(servoId, registerId, 2, result);
+	if (rc < 0)
+		return 0;
+	return result[0] + (result[1] << 8);
 }
 
 int STSServoDriver::readRegisters(byte const &servoId,
-                                  byte const &startRegister,
-                                  byte const &readLength,
-                                  byte *outputBuffer)
+								  byte const &startRegister,
+								  byte const &readLength,
+								  byte *outputBuffer)
 {
-    byte readParam[2] = {startRegister, readLength};
-    // Flush
-    while (port_->read() != -1)
-        ;
-    ;
-    int send = sendMessage(servoId, instruction::READ, 2, readParam);
-    // Failed to send
-    if (send != 8)
-        return -1;
-    // Read
-    byte result[readLength + 1];
-    int rd = recieveMessage(servoId, readLength + 1, result);
-    if (rd < 0)
-        return rd;
+	byte readParam[2] = {startRegister, readLength};
+	// Flush
+	while (port_->read() != -1)
+		;
+	;
+	int send = sendMessage(servoId, instruction::READ, 2, readParam);
+	// Failed to send
+	if (send != 8)
+		return -1;
+	// Read
+	byte result[readLength + 1];
+	int rd = recieveMessage(servoId, readLength + 1, result);
+	if (rd < 0)
+		return rd;
 
-    for (int i = 0; i < readLength; i++)
-        outputBuffer[i] = result[i + 1];
-    return 0;
+	for (int i = 0; i < readLength; i++)
+		outputBuffer[i] = result[i + 1];
+	return 0;
 }
 
 int STSServoDriver::recieveMessage(byte const &servoId,
-                                   byte const &readLength,
-                                   byte *outputBuffer)
+								   byte const &readLength,
+								   byte *outputBuffer)
 {
-    digitalWrite(dirPin_, LOW);
-    byte result[readLength + 5];
-    size_t rd = port_->readBytes(result, readLength + 5);
-    if (rd != (unsigned short)(readLength + 5))
-        return -1;
-    // Check message integrity
-    if (result[0] != 0xFF || result[1] != 0xFF || result[2] != servoId || result[3] != readLength + 1)
-        return -2;
-    byte checksum = 0;
-    for (int i = 2; i < readLength + 4; i++)
-        checksum += result[i];
-    checksum = ~checksum;
-    if (result[readLength + 4] != checksum)
-        return -3;
+	digitalWrite(dirPin_, LOW);
+	byte result[readLength + 5];
+	size_t rd = port_->readBytes(result, readLength + 5);
+	if (rd != (unsigned short)(readLength + 5))
+		return -1;
+	// Check message integrity
+	if (result[0] != 0xFF || result[1] != 0xFF || result[2] != servoId || result[3] != readLength + 1)
+		return -2;
+	byte checksum = 0;
+	for (int i = 2; i < readLength + 4; i++)
+		checksum += result[i];
+	checksum = ~checksum;
+	if (result[readLength + 4] != checksum)
+		return -3;
 
-    // Copy result to output buffer
-    for (int i = 0; i < readLength; i++)
-        outputBuffer[i] = result[i + 4];
-    return 0;
+	// Copy result to output buffer
+	for (int i = 0; i < readLength; i++)
+		outputBuffer[i] = result[i + 4];
+	return 0;
 }
 
 void STSServoDriver::convertIntToBytes(int const &value, byte result[2])
 {
-    result[0] = value & 0xFF;
-    result[1] = (value >> 8) & 0xFF;
+	result[0] = value & 0xFF;
+	result[1] = (value >> 8) & 0xFF;
 }
 
 void STSServoDriver::sendAndUpdateChecksum(byte convertedValue[], byte &checksum)
 {
-    port_->write(convertedValue, 2);
-    checksum += convertedValue[0] + convertedValue[1];
+	port_->write(convertedValue, 2);
+	checksum += convertedValue[0] + convertedValue[1];
 }
 
-void STSServoDriver::setTargetPositions(const byte servoIds[],
-                                        const int positions[],
-                                        const int speeds[])
+void STSServoDriver::setTargetPositions(byte const &NumberOfServos, const byte servoIds[],
+										const int positions[],
+										const int speeds[])
 {
-    port_->write(0xFF);
-    port_->write(0xFF);
-    port_->write(0XFE);
-    port_->write(sizeof(servoIds) * 7 + 4);
-    port_->write(instruction::SYNCWRITE);
-    port_->write(STSRegisters::TARGET_POSITION);
-    port_->write(6);
-    byte checksum = 0xFE + sizeof(servoIds) * 7 + 4 + instruction::SYNCWRITE + STSRegisters::TARGET_POSITION + 6;
-    for (int index = 0; index < sizeof(servoIds); index++)
-    {
-        checksum += servoIds[index];
-        port_->write(servoIds[index]);
-        byte intAsByte[2];
-        convertIntToBytes(positions[index], intAsByte);
-        sendAndUpdateChecksum(intAsByte, checksum);
-        port_->write(0);
-        port_->write(0);
-        convertIntToBytes(speeds[index], intAsByte);
-        sendAndUpdateChecksum(intAsByte, checksum);
-    }
-    port_->write(~checksum);
+	port_->write(0xFF);
+	port_->write(0xFF);
+	port_->write(0XFE);
+	port_->write(NumberOfServos * 7 + 4);
+	port_->write(instruction::SYNCWRITE);
+	port_->write(STSRegisters::TARGET_POSITION);
+	port_->write(6);
+	byte checksum = 0xFE + NumberOfServos * 7 + 4 + instruction::SYNCWRITE + STSRegisters::TARGET_POSITION + 6;
+	for (int index = 0; index < NumberOfServos; index++)
+	{
+		checksum += servoIds[index];
+		port_->write(servoIds[index]);
+		byte intAsByte[2];
+		convertIntToBytes(positions[index], intAsByte);
+		sendAndUpdateChecksum(intAsByte, checksum);
+		port_->write(0);
+		port_->write(0);
+		convertIntToBytes(speeds[index], intAsByte);
+		sendAndUpdateChecksum(intAsByte, checksum);
+	}
+	port_->write(~checksum);
 }

--- a/src/STSServoDriver.cpp
+++ b/src/STSServoDriver.cpp
@@ -130,7 +130,7 @@ bool STSServoDriver::setTargetVelocity(byte const &servoId, int const &velocity,
 
 bool STSServoDriver::setTargetAcceleration(byte const &servoId, byte const &acceleration, bool const &asynchronous)
 {
-	return writeRegister(servoId, STSRegisters::TARGET_ACCELERATION, acceleration, asynchronous)
+	return writeRegister(servoId, STSRegisters::TARGET_ACCELERATION, acceleration, asynchronous);
 }
 
 bool STSServoDriver::trigerAction()

--- a/src/STSServoDriver.cpp
+++ b/src/STSServoDriver.cpp
@@ -264,9 +264,9 @@ void STSServoDriver::sendAndUpdateChecksum(byte convertedValue[], byte &checksum
     checksum += convertedValue[0] + convertedValue[1];
 }
 
-void STSServoDriver::setTargetPositions(byte servoIds[],
-                                        int positions[],
-                                        int speeds[])
+void STSServoDriver::setTargetPositions(const byte servoIds[],
+                                        const int positions[],
+                                        const int speeds[])
 {
     port_->write(0xFF);
     port_->write(0xFF);

--- a/src/STSServoDriver.cpp
+++ b/src/STSServoDriver.cpp
@@ -2,28 +2,25 @@
 
 namespace instruction
 {
-    byte const PING      = 0x01;
-    byte const READ      = 0x02;
-    byte const WRITE     = 0x03;
-    byte const REGWRITE  = 0x04;
-    byte const ACTION    = 0x05;
+    byte const PING = 0x01;
+    byte const READ = 0x02;
+    byte const WRITE = 0x03;
+    byte const REGWRITE = 0x04;
+    byte const ACTION = 0x05;
     byte const SYNCWRITE = 0x83;
-    byte const RESET     = 0x06;
+    byte const RESET = 0x06;
 };
 
-
-STSServoDriver::STSServoDriver():
-    dirPin_(0)
+STSServoDriver::STSServoDriver() : dirPin_(0)
 {
 }
 
-
-bool STSServoDriver::init(byte const& dirPin, HardwareSerial *serialPort,long const& baudRate)
+bool STSServoDriver::init(byte const &dirPin, HardwareSerial *serialPort, long const &baudRate)
 {
-    #ifdef SERIAL_H
+#ifdef SERIAL_H
     if (serialPort == nullptr)
         serialPort = &Serial;
-    #endif
+#endif
     // Open port
     port_ = serialPort;
     port_->begin(baudRate);
@@ -37,8 +34,7 @@ bool STSServoDriver::init(byte const& dirPin, HardwareSerial *serialPort,long co
     return false;
 }
 
-
-bool STSServoDriver::ping(byte const& servoId)
+bool STSServoDriver::ping(byte const &servoId)
 {
     byte response[1] = {0xFF};
     int send = sendMessage(servoId,
@@ -55,8 +51,7 @@ bool STSServoDriver::ping(byte const& servoId)
     return response[0] == 0x00;
 }
 
-
-bool STSServoDriver::setId(byte const& oldServoId, byte const& newServoId)
+bool STSServoDriver::setId(byte const &oldServoId, byte const &newServoId)
 {
     if (oldServoId >= 0xFE || newServoId >= 0xFE)
         return false;
@@ -70,55 +65,48 @@ bool STSServoDriver::setId(byte const& oldServoId, byte const& newServoId)
         return false;
     // Lock EEPROM
     if (!writeRegister(newServoId, STSRegisters::WRITE_LOCK, 1))
-      return false;
+        return false;
     return ping(newServoId);
 }
 
-
-int STSServoDriver::getCurrentPosition(byte const& servoId)
+int STSServoDriver::getCurrentPosition(byte const &servoId)
 {
     int16_t pos = readTwoBytesRegister(servoId, STSRegisters::CURRENT_POSITION);
     return pos;
 }
 
-
-int STSServoDriver::getCurrentSpeed(byte const& servoId)
+int STSServoDriver::getCurrentSpeed(byte const &servoId)
 {
     int16_t vel = readTwoBytesRegister(servoId, STSRegisters::CURRENT_SPEED);
     return vel;
 }
 
-
-int STSServoDriver::getCurrentTemperature(byte const& servoId)
+int STSServoDriver::getCurrentTemperature(byte const &servoId)
 {
     return readTwoBytesRegister(servoId, STSRegisters::CURRENT_TEMPERATURE);
 }
 
-
-int STSServoDriver::getCurrentCurrent(byte const& servoId)
+int STSServoDriver::getCurrentCurrent(byte const &servoId)
 {
     int16_t current = readTwoBytesRegister(servoId, STSRegisters::CURRENT_CURRENT);
     return current * 0.0065;
 }
 
-bool STSServoDriver::isMoving(byte const& servoId)
+bool STSServoDriver::isMoving(byte const &servoId)
 {
     byte const result = readRegister(servoId, STSRegisters::MOVING_STATUS);
     return result > 0;
 }
 
-
-bool STSServoDriver::setTargetPosition(byte const& servoId, int const& position, bool const& asynchronous)
+bool STSServoDriver::setTargetPosition(byte const &servoId, int const &position, bool const &asynchronous)
 {
     return writeTwoBytesRegister(servoId, STSRegisters::TARGET_POSITION, position, asynchronous);
 }
 
-
-bool STSServoDriver::setTargetVelocity(byte const& servoId, int const& velocity, bool const& asynchronous)
+bool STSServoDriver::setTargetVelocity(byte const &servoId, int const &velocity, bool const &asynchronous)
 {
     return writeTwoBytesRegister(servoId, STSRegisters::RUNNING_SPEED, velocity, asynchronous);
 }
-
 
 bool STSServoDriver::trigerAction()
 {
@@ -127,9 +115,9 @@ bool STSServoDriver::trigerAction()
     return send == 6;
 }
 
-int STSServoDriver::sendMessage(byte const& servoId,
-                                byte const& commandID,
-                                byte const& paramLength,
+int STSServoDriver::sendMessage(byte const &servoId,
+                                byte const &commandID,
+                                byte const &paramLength,
                                 byte *parameters)
 {
     byte message[6 + paramLength];
@@ -154,46 +142,42 @@ int STSServoDriver::sendMessage(byte const& servoId,
     return ret;
 }
 
-
-bool STSServoDriver::writeRegisters(byte const& servoId,
-                                    byte const& startRegister,
-                                    byte const& writeLength,
+bool STSServoDriver::writeRegisters(byte const &servoId,
+                                    byte const &startRegister,
+                                    byte const &writeLength,
                                     byte const *parameters,
-                                    bool const& asynchronous)
+                                    bool const &asynchronous)
 {
     byte param[writeLength + 1];
     param[0] = startRegister;
     for (int i = 0; i < writeLength; i++)
         param[i + 1] = parameters[i];
-    int rc =  sendMessage(servoId,
-                          asynchronous ? instruction::REGWRITE : instruction::WRITE,
-                          writeLength + 1,
-                          param);
+    int rc = sendMessage(servoId,
+                         asynchronous ? instruction::REGWRITE : instruction::WRITE,
+                         writeLength + 1,
+                         param);
     return rc == writeLength + 7;
 }
 
-
-bool STSServoDriver::writeRegister(byte const& servoId,
-                                   byte const& registerId,
-                                   byte const& value,
-                                   bool const& asynchronous)
+bool STSServoDriver::writeRegister(byte const &servoId,
+                                   byte const &registerId,
+                                   byte const &value,
+                                   bool const &asynchronous)
 {
     return writeRegisters(servoId, registerId, 1, &value, asynchronous);
 }
 
-
-bool STSServoDriver::writeTwoBytesRegister(byte const& servoId,
-                                           byte const& registerId,
-                                           int16_t const& value,
-                                           bool const& asynchronous)
+bool STSServoDriver::writeTwoBytesRegister(byte const &servoId,
+                                           byte const &registerId,
+                                           int16_t const &value,
+                                           bool const &asynchronous)
 {
     byte params[2] = {static_cast<unsigned char>(value & 0xFF),
-                               static_cast<unsigned char>((value >> 8) & 0xFF)};
+                      static_cast<unsigned char>((value >> 8) & 0xFF)};
     return writeRegisters(servoId, registerId, 2, params, asynchronous);
 }
 
-
-byte STSServoDriver::readRegister(byte const& servoId, byte const& registerId)
+byte STSServoDriver::readRegister(byte const &servoId, byte const &registerId)
 {
     byte result = 0;
     int rc = readRegisters(servoId, registerId, 1, &result);
@@ -202,8 +186,7 @@ byte STSServoDriver::readRegister(byte const& servoId, byte const& registerId)
     return result;
 }
 
-
-int16_t STSServoDriver::readTwoBytesRegister(byte const& servoId, byte const& registerId)
+int16_t STSServoDriver::readTwoBytesRegister(byte const &servoId, byte const &registerId)
 {
     byte result[2] = {0, 0};
     int rc = readRegisters(servoId, registerId, 2, result);
@@ -212,15 +195,16 @@ int16_t STSServoDriver::readTwoBytesRegister(byte const& servoId, byte const& re
     return result[0] + (result[1] << 8);
 }
 
-
-int STSServoDriver::readRegisters(byte const& servoId,
-                                  byte const& startRegister,
-                                  byte const& readLength,
+int STSServoDriver::readRegisters(byte const &servoId,
+                                  byte const &startRegister,
+                                  byte const &readLength,
                                   byte *outputBuffer)
 {
     byte readParam[2] = {startRegister, readLength};
     // Flush
-	while(port_->read()!=-1);;
+    while (port_->read() != -1)
+        ;
+    ;
     int send = sendMessage(servoId, instruction::READ, 2, readParam);
     // Failed to send
     if (send != 8)
@@ -236,8 +220,8 @@ int STSServoDriver::readRegisters(byte const& servoId,
     return 0;
 }
 
-int STSServoDriver::recieveMessage(byte const& servoId,
-                                   byte const& readLength,
+int STSServoDriver::recieveMessage(byte const &servoId,
+                                   byte const &readLength,
                                    byte *outputBuffer)
 {
     digitalWrite(dirPin_, LOW);
@@ -259,4 +243,43 @@ int STSServoDriver::recieveMessage(byte const& servoId,
     for (int i = 0; i < readLength; i++)
         outputBuffer[i] = result[i + 4];
     return 0;
+}
+
+void STSServoDriver::convertIntToBytes(int const &value, byte result[2])
+{
+    result[0] = value & 0xFF;
+    result[1] = (value >> 8) & 0xFF;
+}
+
+void STSServoDriver::sendAndUpdateChecksum(byte convertedValue[], byte &checksum)
+{
+    port_->write(convertedValue, 2);
+    checksum += convertedValue[0] + convertedValue[1];
+}
+
+void STSServoDriver::setTargetPositions(byte servoIds[],
+                                        int positions[],
+                                        int speeds[])
+{
+    port_->write(0xFF);
+    port_->write(0xFF);
+    port_->write(0XFE);
+    port_->write(sizeof(servoIds) * 7 + 4);
+    port_->write(instruction::SYNCWRITE);
+    port_->write(STSRegisters::TARGET_POSITION);
+    port_->write(6);
+    byte checksum = 0xFE + sizeof(servoIds) * 7 + 4 + instruction::SYNCWRITE + STSRegisters::TARGET_POSITION + 6;
+    for (int index = 0; index < sizeof(servoIds); index++)
+    {
+        checksum += servoIds[index];
+        port_->write(servoIds[index]);
+        byte intAsByte[2];
+        convertIntToBytes(positions[index], intAsByte);
+        sendAndUpdateChecksum(intAsByte, checksum);
+        port_->write(0);
+        port_->write(0);
+        convertIntToBytes(speeds[index], intAsByte);
+        sendAndUpdateChecksum(intAsByte, checksum);
+    }
+    port_->write(~checksum);
 }

--- a/src/STSServoDriver.cpp
+++ b/src/STSServoDriver.cpp
@@ -69,6 +69,11 @@ bool STSServoDriver::setId(byte const &oldServoId, byte const &newServoId)
 	return ping(newServoId);
 }
 
+bool STSServoDriver::setGoalAcceleration(byte const &servoId, byte const &acceleration)
+{
+	return writeRegister(servoId, STSRegisters::TARGET_ACCELERATION, acceleration)
+}
+
 int STSServoDriver::getCurrentPosition(byte const &servoId)
 {
 	int16_t pos = readTwoBytesRegister(servoId, STSRegisters::CURRENT_POSITION);

--- a/src/STSServoDriver.cpp
+++ b/src/STSServoDriver.cpp
@@ -2,13 +2,13 @@
 
 namespace instruction
 {
-	byte const PING = 0x01;
-	byte const READ = 0x02;
-	byte const WRITE = 0x03;
-	byte const REGWRITE = 0x04;
-	byte const ACTION = 0x05;
-	byte const SYNCWRITE = 0x83;
-	byte const RESET = 0x06;
+  byte const PING       = 0x01;
+  byte const READ       = 0x02;
+  byte const WRITE      = 0x03;
+  byte const REGWRITE   = 0x04;
+  byte const ACTION     = 0x05;
+  byte const SYNCWRITE  = 0x83;
+  byte const RESET      = 0x06;
 };
 
 STSServoDriver::STSServoDriver() : dirPin_(0)
@@ -18,293 +18,293 @@ STSServoDriver::STSServoDriver() : dirPin_(0)
 bool STSServoDriver::init(byte const &dirPin, HardwareSerial *serialPort, long const &baudRate)
 {
 #ifdef SERIAL_H
-	if (serialPort == nullptr)
-		serialPort = &Serial;
+  if (serialPort == nullptr)
+    serialPort = &Serial;
 #endif
-	// Open port
-	port_ = serialPort;
-	port_->begin(baudRate);
-	dirPin_ = dirPin;
-	pinMode(dirPin_, OUTPUT);
+  // Open port
+  port_ = serialPort;
+  port_->begin(baudRate);
+  dirPin_ = dirPin;
+  pinMode(dirPin_, OUTPUT);
 
-	// Test that a servo is present.
-	for (byte i = 0; i < 0xFE; i++)
-		if (ping(i))
-			return true;
-	return false;
+  // Test that a servo is present.
+  for (byte i = 0; i < 0xFE; i++)
+    if (ping(i))
+      return true;
+  return false;
 }
 
 bool STSServoDriver::ping(byte const &servoId)
 {
-	byte response[1] = {0xFF};
-	int send = sendMessage(servoId,
-						   instruction::PING,
-						   0,
-						   response);
-	// Failed to send
-	if (send != 6)
-		return false;
-	// Read response
-	int rd = recieveMessage(servoId, 1, response);
-	if (rd < 0)
-		return false;
-	return response[0] == 0x00;
+  byte response[1] = {0xFF};
+  int send = sendMessage(servoId,
+                         instruction::PING,
+                         0,
+                         response);
+  // Failed to send
+  if (send != 6)
+    return false;
+  // Read response
+  int rd = recieveMessage(servoId, 1, response);
+  if (rd < 0)
+    return false;
+  return response[0] == 0x00;
 }
 
 bool STSServoDriver::setId(byte const &oldServoId, byte const &newServoId)
 {
-	if (oldServoId >= 0xFE || newServoId >= 0xFE)
-		return false;
-	if (ping(newServoId))
-		return false; // address taken
-	// Unlock EEPROM
-	if (!writeRegister(oldServoId, STSRegisters::WRITE_LOCK, 0))
-		return false;
-	// Write new ID
-	if (!writeRegister(oldServoId, STSRegisters::ID, newServoId))
-		return false;
-	// Lock EEPROM
-	if (!writeRegister(newServoId, STSRegisters::WRITE_LOCK, 1))
-		return false;
-	return ping(newServoId);
+  if (oldServoId >= 0xFE || newServoId >= 0xFE)
+    return false;
+  if (ping(newServoId))
+    return false; // address taken
+  // Unlock EEPROM
+  if (!writeRegister(oldServoId, STSRegisters::WRITE_LOCK, 0))
+    return false;
+  // Write new ID
+  if (!writeRegister(oldServoId, STSRegisters::ID, newServoId))
+    return false;
+  // Lock EEPROM
+  if (!writeRegister(newServoId, STSRegisters::WRITE_LOCK, 1))
+    return false;
+  return ping(newServoId);
 }
 
 bool STSServoDriver::setPositionOffset(byte const &servoId, int const &positionOffset)
 {
-	if (!writeRegister(servoId, STSRegisters::WRITE_LOCK, 0))
-		return false;
-	// Write new position offset
-	if (!writeTwoBytesRegister(servoId, STSRegisters::POSITION_CORRECTION, positionOffset))
-		return false;
-	// Lock EEPROM
-	if (!writeRegister(servoId, STSRegisters::WRITE_LOCK, 1))
-		return false;
-	return true;
+  if (!writeRegister(servoId, STSRegisters::WRITE_LOCK, 0))
+    return false;
+  // Write new position offset
+  if (!writeTwoBytesRegister(servoId, STSRegisters::POSITION_CORRECTION, positionOffset))
+    return false;
+  // Lock EEPROM
+  if (!writeRegister(servoId, STSRegisters::WRITE_LOCK, 1))
+    return false;
+  return true;
 }
 
 int STSServoDriver::getCurrentPosition(byte const &servoId)
 {
-	int16_t pos = readTwoBytesRegister(servoId, STSRegisters::CURRENT_POSITION);
-	return pos;
+  int16_t pos = readTwoBytesRegister(servoId, STSRegisters::CURRENT_POSITION);
+  return pos;
 }
 
 int STSServoDriver::getCurrentSpeed(byte const &servoId)
 {
-	int16_t vel = readTwoBytesRegister(servoId, STSRegisters::CURRENT_SPEED);
-	return vel;
+  int16_t vel = readTwoBytesRegister(servoId, STSRegisters::CURRENT_SPEED);
+  return vel;
 }
 
 int STSServoDriver::getCurrentTemperature(byte const &servoId)
 {
-	return readTwoBytesRegister(servoId, STSRegisters::CURRENT_TEMPERATURE);
+  return readTwoBytesRegister(servoId, STSRegisters::CURRENT_TEMPERATURE);
 }
 
 int STSServoDriver::getCurrentCurrent(byte const &servoId)
 {
-	int16_t current = readTwoBytesRegister(servoId, STSRegisters::CURRENT_CURRENT);
-	return current * 0.0065;
+  int16_t current = readTwoBytesRegister(servoId, STSRegisters::CURRENT_CURRENT);
+  return current * 0.0065;
 }
 
 bool STSServoDriver::isMoving(byte const &servoId)
 {
-	byte const result = readRegister(servoId, STSRegisters::MOVING_STATUS);
-	return result > 0;
+  byte const result = readRegister(servoId, STSRegisters::MOVING_STATUS);
+  return result > 0;
 }
 
 bool STSServoDriver::setTargetPosition(byte const &servoId, int const &position, int const &speed, bool const &asynchronous)
 {
-	byte params[6] = {
-		static_cast<unsigned char>(position & 0xFF),
-		static_cast<unsigned char>((position >> 8) & 0xFF),
-		0,
-		0,
-		static_cast<unsigned char>(speed & 0xFF),
-		static_cast<unsigned char>((speed >> 8) & 0xFF)};
-	return writeRegisters(servoId, STSRegisters::TARGET_POSITION, sizeof(params), params, asynchronous);
+  byte params[6] = {
+      static_cast<unsigned char>(position & 0xFF),
+      static_cast<unsigned char>((position >> 8) & 0xFF),
+      0,
+      0,
+      static_cast<unsigned char>(speed & 0xFF),
+      static_cast<unsigned char>((speed >> 8) & 0xFF)};
+  return writeRegisters(servoId, STSRegisters::TARGET_POSITION, sizeof(params), params, asynchronous);
 }
 
 bool STSServoDriver::setTargetVelocity(byte const &servoId, int const &velocity, bool const &asynchronous)
 {
-	return writeTwoBytesRegister(servoId, STSRegisters::RUNNING_SPEED, velocity, asynchronous);
+  return writeTwoBytesRegister(servoId, STSRegisters::RUNNING_SPEED, velocity, asynchronous);
 }
 
 bool STSServoDriver::setTargetAcceleration(byte const &servoId, byte const &acceleration, bool const &asynchronous)
 {
-	return writeRegister(servoId, STSRegisters::TARGET_ACCELERATION, acceleration, asynchronous);
+  return writeRegister(servoId, STSRegisters::TARGET_ACCELERATION, acceleration, asynchronous);
 }
 
 bool STSServoDriver::trigerAction()
 {
-	byte noParam = 0;
-	int send = sendMessage(0xFE, instruction::ACTION, 0, &noParam);
-	return send == 6;
+  byte noParam = 0;
+  int send = sendMessage(0xFE, instruction::ACTION, 0, &noParam);
+  return send == 6;
 }
 
 int STSServoDriver::sendMessage(byte const &servoId,
-								byte const &commandID,
-								byte const &paramLength,
-								byte *parameters)
+                                byte const &commandID,
+                                byte const &paramLength,
+                                byte *parameters)
 {
-	byte message[6 + paramLength];
-	byte checksum = servoId + paramLength + 2 + commandID;
-	message[0] = 0xFF;
-	message[1] = 0xFF;
-	message[2] = servoId;
-	message[3] = paramLength + 2;
-	message[4] = commandID;
-	for (int i = 0; i < paramLength; i++)
-	{
-		message[5 + i] = parameters[i];
-		checksum += parameters[i];
-	}
-	message[5 + paramLength] = ~checksum;
+  byte message[6 + paramLength];
+  byte checksum = servoId + paramLength + 2 + commandID;
+  message[0] = 0xFF;
+  message[1] = 0xFF;
+  message[2] = servoId;
+  message[3] = paramLength + 2;
+  message[4] = commandID;
+  for (int i = 0; i < paramLength; i++)
+  {
+    message[5 + i] = parameters[i];
+    checksum += parameters[i];
+  }
+  message[5 + paramLength] = ~checksum;
 
-	digitalWrite(dirPin_, HIGH);
-	int ret = port_->write(message, 6 + paramLength);
-	digitalWrite(dirPin_, LOW);
-	// Give time for the message to be processed.
-	delayMicroseconds(200);
-	return ret;
+  digitalWrite(dirPin_, HIGH);
+  int ret = port_->write(message, 6 + paramLength);
+  digitalWrite(dirPin_, LOW);
+  // Give time for the message to be processed.
+  delayMicroseconds(200);
+  return ret;
 }
 
 bool STSServoDriver::writeRegisters(byte const &servoId,
-									byte const &startRegister,
-									byte const &writeLength,
-									byte const *parameters,
-									bool const &asynchronous)
+                                    byte const &startRegister,
+                                    byte const &writeLength,
+                                    byte const *parameters,
+                                    bool const &asynchronous)
 {
-	byte param[writeLength + 1];
-	param[0] = startRegister;
-	for (int i = 0; i < writeLength; i++)
-		param[i + 1] = parameters[i];
-	int rc = sendMessage(servoId,
-						 asynchronous ? instruction::REGWRITE : instruction::WRITE,
-						 writeLength + 1,
-						 param);
-	return rc == writeLength + 7;
+  byte param[writeLength + 1];
+  param[0] = startRegister;
+  for (int i = 0; i < writeLength; i++)
+    param[i + 1] = parameters[i];
+  int rc = sendMessage(servoId,
+                       asynchronous ? instruction::REGWRITE : instruction::WRITE,
+                       writeLength + 1,
+                       param);
+  return rc == writeLength + 7;
 }
 
 bool STSServoDriver::writeRegister(byte const &servoId,
-								   byte const &registerId,
-								   byte const &value,
-								   bool const &asynchronous)
+                                   byte const &registerId,
+                                   byte const &value,
+                                   bool const &asynchronous)
 {
-	return writeRegisters(servoId, registerId, 1, &value, asynchronous);
+  return writeRegisters(servoId, registerId, 1, &value, asynchronous);
 }
 
 bool STSServoDriver::writeTwoBytesRegister(byte const &servoId,
-										   byte const &registerId,
-										   int16_t const &value,
-										   bool const &asynchronous)
+                                           byte const &registerId,
+                                           int16_t const &value,
+                                           bool const &asynchronous)
 {
-	byte params[2] = {static_cast<unsigned char>(value & 0xFF),
-					  static_cast<unsigned char>((value >> 8) & 0xFF)};
-	return writeRegisters(servoId, registerId, 2, params, asynchronous);
+  byte params[2] = {static_cast<unsigned char>(value & 0xFF),
+                    static_cast<unsigned char>((value >> 8) & 0xFF)};
+  return writeRegisters(servoId, registerId, 2, params, asynchronous);
 }
 
 byte STSServoDriver::readRegister(byte const &servoId, byte const &registerId)
 {
-	byte result = 0;
-	int rc = readRegisters(servoId, registerId, 1, &result);
-	if (rc < 0)
-		return 0;
-	return result;
+  byte result = 0;
+  int rc = readRegisters(servoId, registerId, 1, &result);
+  if (rc < 0)
+    return 0;
+  return result;
 }
 
 int16_t STSServoDriver::readTwoBytesRegister(byte const &servoId, byte const &registerId)
 {
-	byte result[2] = {0, 0};
-	int rc = readRegisters(servoId, registerId, 2, result);
-	if (rc < 0)
-		return 0;
-	return result[0] + (result[1] << 8);
+  byte result[2] = {0, 0};
+  int rc = readRegisters(servoId, registerId, 2, result);
+  if (rc < 0)
+    return 0;
+  return result[0] + (result[1] << 8);
 }
 
 int STSServoDriver::readRegisters(byte const &servoId,
-								  byte const &startRegister,
-								  byte const &readLength,
-								  byte *outputBuffer)
+                                  byte const &startRegister,
+                                  byte const &readLength,
+                                  byte *outputBuffer)
 {
-	byte readParam[2] = {startRegister, readLength};
-	// Flush
-	while (port_->read() != -1)
-		;
-	;
-	int send = sendMessage(servoId, instruction::READ, 2, readParam);
-	// Failed to send
-	if (send != 8)
-		return -1;
-	// Read
-	byte result[readLength + 1];
-	int rd = recieveMessage(servoId, readLength + 1, result);
-	if (rd < 0)
-		return rd;
+  byte readParam[2] = {startRegister, readLength};
+  // Flush
+  while (port_->read() != -1)
+    ;
+  ;
+  int send = sendMessage(servoId, instruction::READ, 2, readParam);
+  // Failed to send
+  if (send != 8)
+    return -1;
+  // Read
+  byte result[readLength + 1];
+  int rd = recieveMessage(servoId, readLength + 1, result);
+  if (rd < 0)
+    return rd;
 
-	for (int i = 0; i < readLength; i++)
-		outputBuffer[i] = result[i + 1];
-	return 0;
+  for (int i = 0; i < readLength; i++)
+    outputBuffer[i] = result[i + 1];
+  return 0;
 }
 
 int STSServoDriver::recieveMessage(byte const &servoId,
-								   byte const &readLength,
-								   byte *outputBuffer)
+                                   byte const &readLength,
+                                   byte *outputBuffer)
 {
-	digitalWrite(dirPin_, LOW);
-	byte result[readLength + 5];
-	size_t rd = port_->readBytes(result, readLength + 5);
-	if (rd != (unsigned short)(readLength + 5))
-		return -1;
-	// Check message integrity
-	if (result[0] != 0xFF || result[1] != 0xFF || result[2] != servoId || result[3] != readLength + 1)
-		return -2;
-	byte checksum = 0;
-	for (int i = 2; i < readLength + 4; i++)
-		checksum += result[i];
-	checksum = ~checksum;
-	if (result[readLength + 4] != checksum)
-		return -3;
+  digitalWrite(dirPin_, LOW);
+  byte result[readLength + 5];
+  size_t rd = port_->readBytes(result, readLength + 5);
+  if (rd != (unsigned short)(readLength + 5))
+    return -1;
+  // Check message integrity
+  if (result[0] != 0xFF || result[1] != 0xFF || result[2] != servoId || result[3] != readLength + 1)
+    return -2;
+  byte checksum = 0;
+  for (int i = 2; i < readLength + 4; i++)
+    checksum += result[i];
+  checksum = ~checksum;
+  if (result[readLength + 4] != checksum)
+    return -3;
 
-	// Copy result to output buffer
-	for (int i = 0; i < readLength; i++)
-		outputBuffer[i] = result[i + 4];
-	return 0;
+  // Copy result to output buffer
+  for (int i = 0; i < readLength; i++)
+    outputBuffer[i] = result[i + 4];
+  return 0;
 }
 
 void STSServoDriver::convertIntToBytes(int const &value, byte result[2])
 {
-	result[0] = value & 0xFF;
-	result[1] = (value >> 8) & 0xFF;
+  result[0] = value & 0xFF;
+  result[1] = (value >> 8) & 0xFF;
 }
 
 void STSServoDriver::sendAndUpdateChecksum(byte convertedValue[], byte &checksum)
 {
-	port_->write(convertedValue, 2);
-	checksum += convertedValue[0] + convertedValue[1];
+  port_->write(convertedValue, 2);
+  checksum += convertedValue[0] + convertedValue[1];
 }
 
 void STSServoDriver::setTargetPositions(byte const &NumberOfServos, const byte servoIds[],
-										const int positions[],
-										const int speeds[])
+                                        const int positions[],
+                                        const int speeds[])
 {
-	port_->write(0xFF);
-	port_->write(0xFF);
-	port_->write(0XFE);
-	port_->write(NumberOfServos * 7 + 4);
-	port_->write(instruction::SYNCWRITE);
-	port_->write(STSRegisters::TARGET_POSITION);
-	port_->write(6);
-	byte checksum = 0xFE + NumberOfServos * 7 + 4 + instruction::SYNCWRITE + STSRegisters::TARGET_POSITION + 6;
-	for (int index = 0; index < NumberOfServos; index++)
-	{
-		checksum += servoIds[index];
-		port_->write(servoIds[index]);
-		byte intAsByte[2];
-		convertIntToBytes(positions[index], intAsByte);
-		sendAndUpdateChecksum(intAsByte, checksum);
-		port_->write(0);
-		port_->write(0);
-		convertIntToBytes(speeds[index], intAsByte);
-		sendAndUpdateChecksum(intAsByte, checksum);
-	}
-	port_->write(~checksum);
+  port_->write(0xFF);
+  port_->write(0xFF);
+  port_->write(0XFE);
+  port_->write(NumberOfServos * 7 + 4);
+  port_->write(instruction::SYNCWRITE);
+  port_->write(STSRegisters::TARGET_POSITION);
+  port_->write(6);
+  byte checksum = 0xFE + NumberOfServos * 7 + 4 + instruction::SYNCWRITE + STSRegisters::TARGET_POSITION + 6;
+  for (int index = 0; index < NumberOfServos; index++)
+  {
+    checksum += servoIds[index];
+    port_->write(servoIds[index]);
+    byte intAsByte[2];
+    convertIntToBytes(positions[index], intAsByte);
+    sendAndUpdateChecksum(intAsByte, checksum);
+    port_->write(0);
+    port_->write(0);
+    convertIntToBytes(speeds[index], intAsByte);
+    sendAndUpdateChecksum(intAsByte, checksum);
+  }
+  port_->write(~checksum);
 }

--- a/src/STSServoDriver.h
+++ b/src/STSServoDriver.h
@@ -13,218 +13,235 @@
 
 namespace STSRegisters
 {
-    byte const FIRMWARE_MAJOR          = 0x00;
-    byte const FIRMWARE_MINOR          = 0x01;
-    byte const SERVO_MAJOR             = 0x03;
-    byte const SERVO_MINOR             = 0x04;
-    byte const ID                      = 0x05;
-    byte const BAUDRATE                = 0x06;
-    byte const RESPONSE_DELAY          = 0x07;
-    byte const RESPONSE_STATUS_LEVEL   = 0x08;
-    byte const MINIMUM_ANGLE           = 0x09;
-    byte const MAXIMUM_ANGLE           = 0x0B;
-    byte const MAXIMUM_TEMPERATURE     = 0x0D;
-    byte const MAXIMUM_VOLTAGE         = 0x0E;
-    byte const MINIMUM_VOLTAGE         = 0x0F;
-    byte const MAXIMUM_TORQUE          = 0x10;
-    byte const UNLOADING_CONDITION     = 0x13;
-    byte const LED_ALARM_CONDITION     = 0x14;
-    byte const POS_PROPORTIONAL_GAIN   = 0x15;
-    byte const POS_DERIVATIVE_GAIN     = 0x16;
-    byte const POS_INTEGRAL_GAIN       = 0x17;
-    byte const MINIMUM_STARTUP_FORCE   = 0x18;
-    byte const CK_INSENSITIVE_AREA     = 0x1A;
-    byte const CCK_INSENSITIVE_AREA    = 0x1B;
-    byte const CURRENT_PROTECTION_TH   = 0x1C;
-    byte const ANGULAR_RESOLUTION      = 0x1E;
-    byte const POSITION_CORRECTION     = 0x1F;
-    byte const OPERATION_MODE          = 0x21;
-    byte const TORQUE_PROTECTION_TH    = 0x22;
-    byte const TORQUE_PROTECTION_TIME  = 0x23;
-    byte const OVERLOAD_TORQUE         = 0x24;
+    byte const FIRMWARE_MAJOR = 0x00;
+    byte const FIRMWARE_MINOR = 0x01;
+    byte const SERVO_MAJOR = 0x03;
+    byte const SERVO_MINOR = 0x04;
+    byte const ID = 0x05;
+    byte const BAUDRATE = 0x06;
+    byte const RESPONSE_DELAY = 0x07;
+    byte const RESPONSE_STATUS_LEVEL = 0x08;
+    byte const MINIMUM_ANGLE = 0x09;
+    byte const MAXIMUM_ANGLE = 0x0B;
+    byte const MAXIMUM_TEMPERATURE = 0x0D;
+    byte const MAXIMUM_VOLTAGE = 0x0E;
+    byte const MINIMUM_VOLTAGE = 0x0F;
+    byte const MAXIMUM_TORQUE = 0x10;
+    byte const UNLOADING_CONDITION = 0x13;
+    byte const LED_ALARM_CONDITION = 0x14;
+    byte const POS_PROPORTIONAL_GAIN = 0x15;
+    byte const POS_DERIVATIVE_GAIN = 0x16;
+    byte const POS_INTEGRAL_GAIN = 0x17;
+    byte const MINIMUM_STARTUP_FORCE = 0x18;
+    byte const CK_INSENSITIVE_AREA = 0x1A;
+    byte const CCK_INSENSITIVE_AREA = 0x1B;
+    byte const CURRENT_PROTECTION_TH = 0x1C;
+    byte const ANGULAR_RESOLUTION = 0x1E;
+    byte const POSITION_CORRECTION = 0x1F;
+    byte const OPERATION_MODE = 0x21;
+    byte const TORQUE_PROTECTION_TH = 0x22;
+    byte const TORQUE_PROTECTION_TIME = 0x23;
+    byte const OVERLOAD_TORQUE = 0x24;
     byte const SPEED_PROPORTIONAL_GAIN = 0x25;
-    byte const OVERCURRENT_TIME        = 0x26;
-    byte const SPEED_INTEGRAL_GAIN     = 0x27;
-    byte const TORQUE_SWITCH           = 0x28;
-    byte const TARGET_ACCELERATION     = 0x29;
-    byte const TARGET_POSITION         = 0x2A;
-    byte const RUNNING_TIME            = 0x2C;
-    byte const RUNNING_SPEED           = 0x2E;
-    byte const TORQUE_LIMIT            = 0x30;
-    byte const WRITE_LOCK              = 0x37;
-    byte const CURRENT_POSITION        = 0x38;
-    byte const CURRENT_SPEED           = 0x3A;
-    byte const CURRENT_DRIVE_VOLTAGE   = 0x3C;
-    byte const CURRENT_VOLTAGE         = 0x3E;
-    byte const CURRENT_TEMPERATURE     = 0x3F;
-    byte const ASYNCHRONOUS_WRITE_ST   = 0x40;
-    byte const STATUS                  = 0x41;
-    byte const MOVING_STATUS           = 0x42;
-    byte const CURRENT_CURRENT         = 0x45;
+    byte const OVERCURRENT_TIME = 0x26;
+    byte const SPEED_INTEGRAL_GAIN = 0x27;
+    byte const TORQUE_SWITCH = 0x28;
+    byte const TARGET_ACCELERATION = 0x29;
+    byte const TARGET_POSITION = 0x2A;
+    byte const RUNNING_TIME = 0x2C;
+    byte const RUNNING_SPEED = 0x2E;
+    byte const TORQUE_LIMIT = 0x30;
+    byte const WRITE_LOCK = 0x37;
+    byte const CURRENT_POSITION = 0x38;
+    byte const CURRENT_SPEED = 0x3A;
+    byte const CURRENT_DRIVE_VOLTAGE = 0x3C;
+    byte const CURRENT_VOLTAGE = 0x3E;
+    byte const CURRENT_TEMPERATURE = 0x3F;
+    byte const ASYNCHRONOUS_WRITE_ST = 0x40;
+    byte const STATUS = 0x41;
+    byte const MOVING_STATUS = 0x42;
+    byte const CURRENT_CURRENT = 0x45;
 };
 
 /// \brief Driver for STS servos, using UART
 class STSServoDriver
 {
-    public:
-        /// \brief Contstructor.
-        STSServoDriver();
+public:
+    /// \brief Contstructor.
+    STSServoDriver();
 
-        /// \brief Initialize the servo driver.
-        ///
-        /// \param dirPin Pin used for setting communication direction
-        /// \param serialPort Serial port, default is Serial
-        /// \param baudRate Baud rate, default 1Mbps
-        /// \returns  True on success (at least one servo responds to ping)
-        bool init(byte const& dirPin, HardwareSerial *serialPort = nullptr, long const& baudRate = 1000000);
+    /// \brief Initialize the servo driver.
+    ///
+    /// \param dirPin Pin used for setting communication direction
+    /// \param serialPort Serial port, default is Serial
+    /// \param baudRate Baud rate, default 1Mbps
+    /// \returns  True on success (at least one servo responds to ping)
+    bool init(byte const &dirPin, HardwareSerial *serialPort = nullptr, long const &baudRate = 1000000);
 
-        /// \brief Ping servo
-        /// \param[in] servoId ID of the servo
-        /// \return True if servo responded to ping
-        bool ping(byte const& servoId);
+    /// \brief Ping servo
+    /// \param[in] servoId ID of the servo
+    /// \return True if servo responded to ping
+    bool ping(byte const &servoId);
 
-        /// \brief Change the ID of a servo.
-        /// \note If the desired ID is already taken, this function does nothing and returns false.
-        /// \param[in] oldServoId old servo ID
-        /// \param[in] newServoId new servo ID
-        /// \return True if servo could successfully change ID
-        bool setId(byte const& oldServoId, byte const& newServoId);
+    /// \brief Change the ID of a servo.
+    /// \note If the desired ID is already taken, this function does nothing and returns false.
+    /// \param[in] oldServoId old servo ID
+    /// \param[in] newServoId new servo ID
+    /// \return True if servo could successfully change ID
+    bool setId(byte const &oldServoId, byte const &newServoId);
 
-        /// \brief Get current servo position.
-        /// \note This function assumes that the amplification factor ANGULAR_RESOLUTION is set to 1.
-        /// \param[in] servoId ID of the servo
-        /// \return Position, in counts. 0 on failure.
-        int getCurrentPosition(byte const& servoId);
+    /// \brief Get current servo position.
+    /// \note This function assumes that the amplification factor ANGULAR_RESOLUTION is set to 1.
+    /// \param[in] servoId ID of the servo
+    /// \return Position, in counts. 0 on failure.
+    int getCurrentPosition(byte const &servoId);
 
-        /// \brief Get current servo speed.
-        /// \note This function assumes that the amplification factor ANGULAR_RESOLUTION is set to 1.
-        /// \param[in] servoId ID of the servo
-        /// \return Speed, in counts/s. 0 on failure.
-        int getCurrentSpeed(byte const& servoId);
+    /// \brief Get current servo speed.
+    /// \note This function assumes that the amplification factor ANGULAR_RESOLUTION is set to 1.
+    /// \param[in] servoId ID of the servo
+    /// \return Speed, in counts/s. 0 on failure.
+    int getCurrentSpeed(byte const &servoId);
 
-        /// \brief Get current servo temperature.
-        /// \param[in] servoId ID of the servo
-        /// \return Temperature, in degC. 0 on failure.
-        int getCurrentTemperature(byte const& servoId);
+    /// \brief Get current servo temperature.
+    /// \param[in] servoId ID of the servo
+    /// \return Temperature, in degC. 0 on failure.
+    int getCurrentTemperature(byte const &servoId);
 
-        /// \brief Get current servo current.
-        /// \param[in] servoId ID of the servo
-        /// \return Current, in A.
-        int getCurrentCurrent(byte const& servoId);
+    /// \brief Get current servo current.
+    /// \param[in] servoId ID of the servo
+    /// \return Current, in A.
+    int getCurrentCurrent(byte const &servoId);
 
-        /// \brief Check if the servo is moving
-        /// \param[in] servoId ID of the servo
-        /// \return True if moving, false otherwise.
-        bool isMoving(byte const& servoId);
+    /// \brief Check if the servo is moving
+    /// \param[in] servoId ID of the servo
+    /// \return True if moving, false otherwise.
+    bool isMoving(byte const &servoId);
 
-        /// \brief Set target servo position.
-        /// \note This function assumes that the amplification factor ANGULAR_RESOLUTION is set to 1.
-        /// \param[in] servoId ID of the servo
-        /// \param[in] position Target position, in counts.
-        /// \param[in] asynchronous If set, write is asynchronous (ACTION must be send to activate)
-        /// \return True on success, false otherwise.
-        bool setTargetPosition(byte const& servoId, int const& position, bool const& asynchronous = false);
+    /// \brief Set target servo position.
+    /// \note This function assumes that the amplification factor ANGULAR_RESOLUTION is set to 1.
+    /// \param[in] servoId ID of the servo
+    /// \param[in] position Target position, in counts.
+    /// \param[in] asynchronous If set, write is asynchronous (ACTION must be send to activate)
+    /// \return True on success, false otherwise.
+    bool setTargetPosition(byte const &servoId, int const &position, bool const &asynchronous = false);
 
-        /// \brief Set target servo velocity.
-        /// \note This function assumes that the amplification factor ANGULAR_RESOLUTION is set to 1.
-        /// \param[in] servoId ID of the servo
-        /// \param[in] velocity Target velocity, in counts/s.
-        /// \param[in] asynchronous If set, write is asynchronous (ACTION must be send to activate)
-        /// \return True on success, false otherwise.
-        bool setTargetVelocity(byte const& servoId, int const& velocity, bool const& asynchronous = false);
+    /// \brief Set target servo velocity.
+    /// \note This function assumes that the amplification factor ANGULAR_RESOLUTION is set to 1.
+    /// \param[in] servoId ID of the servo
+    /// \param[in] velocity Target velocity, in counts/s.
+    /// \param[in] asynchronous If set, write is asynchronous (ACTION must be send to activate)
+    /// \return True on success, false otherwise.
+    bool setTargetVelocity(byte const &servoId, int const &velocity, bool const &asynchronous = false);
 
-        /// \brief Trigger the action previously stored by an asynchronous write on all servos.
-        /// \return True on success
-        bool trigerAction();
+    /// \brief Trigger the action previously stored by an asynchronous write on all servos.
+    /// \return True on success
+    bool trigerAction();
 
-        /// \brief Write to a single byte register.
-        /// \param[in] servoId ID of the servo
-        /// \param[in] registerId Register id.
-        /// \param[in] value Register value.
-        /// \param[in] asynchronous If set, write is asynchronous (ACTION must be send to activate)
-        /// \return True if write was successful
-        bool writeRegister(byte const& servoId,
-                            byte const& registerId,
-                            byte const& value,
-                            bool const& asynchronous = false);
+    /// \brief Write to a single byte register.
+    /// \param[in] servoId ID of the servo
+    /// \param[in] registerId Register id.
+    /// \param[in] value Register value.
+    /// \param[in] asynchronous If set, write is asynchronous (ACTION must be send to activate)
+    /// \return True if write was successful
+    bool writeRegister(byte const &servoId,
+                       byte const &registerId,
+                       byte const &value,
+                       bool const &asynchronous = false);
 
-        /// \brief Write a two-bytes register.
-        /// \param[in] servoId ID of the servo
-        /// \param[in] registerId Register id (LSB).
-        /// \param[in] value Register value.
-        /// \param[in] asynchronous If set, write is asynchronous (ACTION must be send to activate)
-        /// \return True if write was successful
-        bool writeTwoBytesRegister(byte const& servoId,
-                                    byte const& registerId,
-                                    int16_t const& value,
-                                    bool const& asynchronous = false);
+    /// \brief Write a two-bytes register.
+    /// \param[in] servoId ID of the servo
+    /// \param[in] registerId Register id (LSB).
+    /// \param[in] value Register value.
+    /// \param[in] asynchronous If set, write is asynchronous (ACTION must be send to activate)
+    /// \return True if write was successful
+    bool writeTwoBytesRegister(byte const &servoId,
+                               byte const &registerId,
+                               int16_t const &value,
+                               bool const &asynchronous = false);
 
-        /// \brief Read a single register
-        /// \param[in] servoId ID of the servo
-        /// \param[in] registerId Register id.
-        /// \return Register value, 0 on failure.
-        byte readRegister(byte const& servoId, byte const& registerId);
+    /// \brief Read a single register
+    /// \param[in] servoId ID of the servo
+    /// \param[in] registerId Register id.
+    /// \return Register value, 0 on failure.
+    byte readRegister(byte const &servoId, byte const &registerId);
 
-        /// \brief Read two bytes, interpret result as <LSB> <MSB>
-        /// \param[in] servoId ID of the servo
-        /// \param[in] registerId LSB register id.
-        /// \return Register value, 0 on failure.
-        int16_t readTwoBytesRegister(byte const& servoId, byte const& registerId);
+    /// \brief Read two bytes, interpret result as <LSB> <MSB>
+    /// \param[in] servoId ID of the servo
+    /// \param[in] registerId LSB register id.
+    /// \return Register value, 0 on failure.
+    int16_t readTwoBytesRegister(byte const &servoId, byte const &registerId);
 
-    private:
+    /// @brief Sets the target positions for multiple servos simultaneously.
+    /// @param[in] servoIds Array of servo IDs to control.
+    /// @param[in] positions Array of target positions (corresponds to servoIds).
+    /// @param[in] speeds Array of target speeds (corresponds to servoIds).
+    void setTargetPositions(byte  servoIds[],
+                           int  positions[], 
+                           int  speeds[]);
 
-        /// \brief Clear internal device error.
-        // void clearError();
+private:
+    /// \brief Clear internal device error.
+    // void clearError();
 
-        /// \brief Send a message to the servos.
-        /// \param[in] servoId ID of the servo
-        /// \param[in] commandID Command id
-        /// \param[in] paramLength length of the parameters
-        /// \param[in] parameters parameters
-        /// \return Result of write.
-        int sendMessage(byte const& servoId,
-                        byte const& commandID,
-                        byte const& paramLength,
-                        byte *parameters);
+    /// \brief Send a message to the servos.
+    /// \param[in] servoId ID of the servo
+    /// \param[in] commandID Command id
+    /// \param[in] paramLength length of the parameters
+    /// \param[in] parameters parameters
+    /// \return Result of write.
+    int sendMessage(byte const &servoId,
+                    byte const &commandID,
+                    byte const &paramLength,
+                    byte *parameters);
 
-        /// \brief Recieve a message from a given servo.
-        /// \param[in] servoId ID of the servo
-        /// \param[in] readLength Message length
-        /// \param[in] paramLength length of the parameters
-        /// \param[in] outputBuffer Buffer where the data is placed.
-        /// \return 0 on success
-        ///         -1 if read failed due to timeout
-        ///         -2 if invalid message (no 0XFF, wrong servo id)
-        ///         -3 if invalid checksum
-        int recieveMessage(byte const& servoId,
-                            byte const& readLength,
-                            byte *outputBuffer);
+    /// \brief Recieve a message from a given servo.
+    /// \param[in] servoId ID of the servo
+    /// \param[in] readLength Message length
+    /// \param[in] paramLength length of the parameters
+    /// \param[in] outputBuffer Buffer where the data is placed.
+    /// \return 0 on success
+    ///         -1 if read failed due to timeout
+    ///         -2 if invalid message (no 0XFF, wrong servo id)
+    ///         -3 if invalid checksum
+    int recieveMessage(byte const &servoId,
+                       byte const &readLength,
+                       byte *outputBuffer);
 
-        /// \brief Write to a sequence of consecutive registers
-        /// \param[in] servoId ID of the servo
-        /// \param[in] startRegister First register
-        /// \param[in] writeLength Number of registers to write
-        /// \param[in] parameters Value of the registers
-        /// \param[in] asynchronous If set, write is asynchronous (ACTION must be send to activate)
-        /// \return True if write was successful
-        bool writeRegisters(byte const& servoId,
-                            byte const& startRegister,
-                            byte const& writeLength,
-                            byte const *parameters,
-                            bool const& asynchronous = false);
+    /// \brief Write to a sequence of consecutive registers
+    /// \param[in] servoId ID of the servo
+    /// \param[in] startRegister First register
+    /// \param[in] writeLength Number of registers to write
+    /// \param[in] parameters Value of the registers
+    /// \param[in] asynchronous If set, write is asynchronous (ACTION must be send to activate)
+    /// \return True if write was successful
+    bool writeRegisters(byte const &servoId,
+                        byte const &startRegister,
+                        byte const &writeLength,
+                        byte const *parameters,
+                        bool const &asynchronous = false);
 
-        /// \brief Read a sequence of consecutive registers.
-        /// \param[in] servoId ID of the servo
-        /// \param[in] startRegister First register
-        /// \param[in] readLength Number of registers to write
-        /// \param[out] outputBuffer Buffer where to read the data (must have been allocated by the user)
-        /// \return 0 on success, -1 if write failed, -2 if read failed, -3 if checksum verification failed
-        int readRegisters(byte const& servoId,
-                            byte const& startRegister,
-                            byte const& readLength,
-                            byte *outputBuffer);
+    /// \brief Read a sequence of consecutive registers.
+    /// \param[in] servoId ID of the servo
+    /// \param[in] startRegister First register
+    /// \param[in] readLength Number of registers to write
+    /// \param[out] outputBuffer Buffer where to read the data (must have been allocated by the user)
+    /// \return 0 on success, -1 if write failed, -2 if read failed, -3 if checksum verification failed
+    int readRegisters(byte const &servoId,
+                      byte const &startRegister,
+                      byte const &readLength,
+                      byte *outputBuffer);
 
-        HardwareSerial *port_;
-        byte dirPin_;     ///< Direction pin number.
+    /// @brief Send two bytes and update checksum  
+    /// @param[in] convertedValue Converted int value 
+    /// @param[out] checksum Update the checksum 
+    void sendAndUpdateChecksum(byte convertedValue[], byte &checksum);
+
+    /// @brief Convert int to pair of bytes
+    /// @param[in] value 
+    /// @param[out] result 
+    void convertIntToBytes(int const &value, byte result[2]);
+
+    HardwareSerial *port_;
+    byte dirPin_; ///< Direction pin number.
 };
 #endif

--- a/src/STSServoDriver.h
+++ b/src/STSServoDriver.h
@@ -13,250 +13,250 @@
 
 namespace STSRegisters
 {
-	byte const FIRMWARE_MAJOR = 0x00;
-	byte const FIRMWARE_MINOR = 0x01;
-	byte const SERVO_MAJOR = 0x03;
-	byte const SERVO_MINOR = 0x04;
-	byte const ID = 0x05;
-	byte const BAUDRATE = 0x06;
-	byte const RESPONSE_DELAY = 0x07;
-	byte const RESPONSE_STATUS_LEVEL = 0x08;
-	byte const MINIMUM_ANGLE = 0x09;
-	byte const MAXIMUM_ANGLE = 0x0B;
-	byte const MAXIMUM_TEMPERATURE = 0x0D;
-	byte const MAXIMUM_VOLTAGE = 0x0E;
-	byte const MINIMUM_VOLTAGE = 0x0F;
-	byte const MAXIMUM_TORQUE = 0x10;
-	byte const UNLOADING_CONDITION = 0x13;
-	byte const LED_ALARM_CONDITION = 0x14;
-	byte const POS_PROPORTIONAL_GAIN = 0x15;
-	byte const POS_DERIVATIVE_GAIN = 0x16;
-	byte const POS_INTEGRAL_GAIN = 0x17;
-	byte const MINIMUM_STARTUP_FORCE = 0x18;
-	byte const CK_INSENSITIVE_AREA = 0x1A;
-	byte const CCK_INSENSITIVE_AREA = 0x1B;
-	byte const CURRENT_PROTECTION_TH = 0x1C;
-	byte const ANGULAR_RESOLUTION = 0x1E;
-	byte const POSITION_CORRECTION = 0x1F;
-	byte const OPERATION_MODE = 0x21;
-	byte const TORQUE_PROTECTION_TH = 0x22;
-	byte const TORQUE_PROTECTION_TIME = 0x23;
-	byte const OVERLOAD_TORQUE = 0x24;
-	byte const SPEED_PROPORTIONAL_GAIN = 0x25;
-	byte const OVERCURRENT_TIME = 0x26;
-	byte const SPEED_INTEGRAL_GAIN = 0x27;
-	byte const TORQUE_SWITCH = 0x28;
-	byte const TARGET_ACCELERATION = 0x29;
-	byte const TARGET_POSITION = 0x2A;
-	byte const RUNNING_TIME = 0x2C;
-	byte const RUNNING_SPEED = 0x2E;
-	byte const TORQUE_LIMIT = 0x30;
-	byte const WRITE_LOCK = 0x37;
-	byte const CURRENT_POSITION = 0x38;
-	byte const CURRENT_SPEED = 0x3A;
-	byte const CURRENT_DRIVE_VOLTAGE = 0x3C;
-	byte const CURRENT_VOLTAGE = 0x3E;
-	byte const CURRENT_TEMPERATURE = 0x3F;
-	byte const ASYNCHRONOUS_WRITE_ST = 0x40;
-	byte const STATUS = 0x41;
-	byte const MOVING_STATUS = 0x42;
-	byte const CURRENT_CURRENT = 0x45;
+  byte const FIRMWARE_MAJOR           = 0x00;
+  byte const FIRMWARE_MINOR           = 0x01;
+  byte const SERVO_MAJOR              = 0x03;
+  byte const SERVO_MINOR              = 0x04;
+  byte const ID                       = 0x05;
+  byte const BAUDRATE                 = 0x06;
+  byte const RESPONSE_DELAY           = 0x07;
+  byte const RESPONSE_STATUS_LEVEL    = 0x08;
+  byte const MINIMUM_ANGLE            = 0x09;
+  byte const MAXIMUM_ANGLE            = 0x0B;
+  byte const MAXIMUM_TEMPERATURE      = 0x0D;
+  byte const MAXIMUM_VOLTAGE          = 0x0E;
+  byte const MINIMUM_VOLTAGE          = 0x0F;
+  byte const MAXIMUM_TORQUE           = 0x10;
+  byte const UNLOADING_CONDITION      = 0x13;
+  byte const LED_ALARM_CONDITION      = 0x14;
+  byte const POS_PROPORTIONAL_GAIN    = 0x15;
+  byte const POS_DERIVATIVE_GAIN      = 0x16;
+  byte const POS_INTEGRAL_GAIN        = 0x17;
+  byte const MINIMUM_STARTUP_FORCE    = 0x18;
+  byte const CK_INSENSITIVE_AREA      = 0x1A;
+  byte const CCK_INSENSITIVE_AREA     = 0x1B;
+  byte const CURRENT_PROTECTION_TH    = 0x1C;
+  byte const ANGULAR_RESOLUTION       = 0x1E;
+  byte const POSITION_CORRECTION      = 0x1F;
+  byte const OPERATION_MODE           = 0x21;
+  byte const TORQUE_PROTECTION_TH     = 0x22;
+  byte const TORQUE_PROTECTION_TIME   = 0x23;
+  byte const OVERLOAD_TORQUE          = 0x24;
+  byte const SPEED_PROPORTIONAL_GAIN  = 0x25;
+  byte const OVERCURRENT_TIME         = 0x26;
+  byte const SPEED_INTEGRAL_GAIN      = 0x27;
+  byte const TORQUE_SWITCH            = 0x28;
+  byte const TARGET_ACCELERATION      = 0x29;
+  byte const TARGET_POSITION          = 0x2A;
+  byte const RUNNING_TIME             = 0x2C;
+  byte const RUNNING_SPEED            = 0x2E;
+  byte const TORQUE_LIMIT             = 0x30;
+  byte const WRITE_LOCK               = 0x37;
+  byte const CURRENT_POSITION         = 0x38;
+  byte const CURRENT_SPEED            = 0x3A;
+  byte const CURRENT_DRIVE_VOLTAGE    = 0x3C;
+  byte const CURRENT_VOLTAGE          = 0x3E;
+  byte const CURRENT_TEMPERATURE      = 0x3F;
+  byte const ASYNCHRONOUS_WRITE_ST    = 0x40;
+  byte const STATUS                   = 0x41;
+  byte const MOVING_STATUS            = 0x42;
+  byte const CURRENT_CURRENT          = 0x45;
 };
 
 /// \brief Driver for STS servos, using UART
 class STSServoDriver
 {
 public:
-	/// \brief Contstructor.
-	STSServoDriver();
+  /// \brief Contstructor.
+  STSServoDriver();
 
-	/// \brief Initialize the servo driver.
-	///
-	/// \param dirPin Pin used for setting communication direction
-	/// \param serialPort Serial port, default is Serial
-	/// \param baudRate Baud rate, default 1Mbps
-	/// \returns  True on success (at least one servo responds to ping)
-	bool init(byte const &dirPin, HardwareSerial *serialPort = nullptr, long const &baudRate = 1000000);
+  /// \brief Initialize the servo driver.
+  ///
+  /// \param dirPin Pin used for setting communication direction
+  /// \param serialPort Serial port, default is Serial
+  /// \param baudRate Baud rate, default 1Mbps
+  /// \returns  True on success (at least one servo responds to ping)
+  bool init(byte const &dirPin, HardwareSerial *serialPort = nullptr, long const &baudRate = 1000000);
 
-	/// \brief Ping servo
-	/// \param[in] servoId ID of the servo
-	/// \return True if servo responded to ping
-	bool ping(byte const &servoId);
+  /// \brief Ping servo
+  /// \param[in] servoId ID of the servo
+  /// \return True if servo responded to ping
+  bool ping(byte const &servoId);
 
-	/// \brief Change the ID of a servo.
-	/// \note If the desired ID is already taken, this function does nothing and returns false.
-	/// \param[in] oldServoId old servo ID
-	/// \param[in] newServoId new servo ID
-	/// \return True if servo could successfully change ID
-	bool setId(byte const &oldServoId, byte const &newServoId);
+  /// \brief Change the ID of a servo.
+  /// \note If the desired ID is already taken, this function does nothing and returns false.
+  /// \param[in] oldServoId old servo ID
+  /// \param[in] newServoId new servo ID
+  /// \return True if servo could successfully change ID
+  bool setId(byte const &oldServoId, byte const &newServoId);
 
-	/// \brief Change the position offset of a servo.
-	/// \param[in] servoId servo ID
-	/// \param[in] positionOffset new position offset
-	/// \return True if servo could successfully change position offset
-	bool setPositionOffset(byte const &servoId, int const &positionOffset);
+  /// \brief Change the position offset of a servo.
+  /// \param[in] servoId servo ID
+  /// \param[in] positionOffset new position offset
+  /// \return True if servo could successfully change position offset
+  bool setPositionOffset(byte const &servoId, int const &positionOffset);
 
-	/// \brief Get current servo position.
-	/// \note This function assumes that the amplification factor ANGULAR_RESOLUTION is set to 1.
-	/// \param[in] servoId ID of the servo
-	/// \return Position, in counts. 0 on failure.
-	int getCurrentPosition(byte const &servoId);
+  /// \brief Get current servo position.
+  /// \note This function assumes that the amplification factor ANGULAR_RESOLUTION is set to 1.
+  /// \param[in] servoId ID of the servo
+  /// \return Position, in counts. 0 on failure.
+  int getCurrentPosition(byte const &servoId);
 
-	/// \brief Get current servo speed.
-	/// \note This function assumes that the amplification factor ANGULAR_RESOLUTION is set to 1.
-	/// \param[in] servoId ID of the servo
-	/// \return Speed, in counts/s. 0 on failure.
-	int getCurrentSpeed(byte const &servoId);
+  /// \brief Get current servo speed.
+  /// \note This function assumes that the amplification factor ANGULAR_RESOLUTION is set to 1.
+  /// \param[in] servoId ID of the servo
+  /// \return Speed, in counts/s. 0 on failure.
+  int getCurrentSpeed(byte const &servoId);
 
-	/// \brief Get current servo temperature.
-	/// \param[in] servoId ID of the servo
-	/// \return Temperature, in degC. 0 on failure.
-	int getCurrentTemperature(byte const &servoId);
+  /// \brief Get current servo temperature.
+  /// \param[in] servoId ID of the servo
+  /// \return Temperature, in degC. 0 on failure.
+  int getCurrentTemperature(byte const &servoId);
 
-	/// \brief Get current servo current.
-	/// \param[in] servoId ID of the servo
-	/// \return Current, in A.
-	int getCurrentCurrent(byte const &servoId);
+  /// \brief Get current servo current.
+  /// \param[in] servoId ID of the servo
+  /// \return Current, in A.
+  int getCurrentCurrent(byte const &servoId);
 
-	/// \brief Check if the servo is moving
-	/// \param[in] servoId ID of the servo
-	/// \return True if moving, false otherwise.
-	bool isMoving(byte const &servoId);
+  /// \brief Check if the servo is moving
+  /// \param[in] servoId ID of the servo
+  /// \return True if moving, false otherwise.
+  bool isMoving(byte const &servoId);
 
-	/// \brief Set target servo position.
-	/// \note This function assumes that the amplification factor ANGULAR_RESOLUTION is set to 1.
-	/// \param[in] servoId ID of the servo
-	/// \param[in] position Target position, in counts.
-	/// \param[in] speed speed of the servo.
-	/// \param[in] asynchronous If set, write is asynchronous (ACTION must be send to activate)
-	/// \return True on success, false otherwise.
-	bool setTargetPosition(byte const &servoId, int const &position, int const &speed, bool const &asynchronous = false);
+  /// \brief Set target servo position.
+  /// \note This function assumes that the amplification factor ANGULAR_RESOLUTION is set to 1.
+  /// \param[in] servoId ID of the servo
+  /// \param[in] position Target position, in counts.
+  /// \param[in] speed speed of the servo.
+  /// \param[in] asynchronous If set, write is asynchronous (ACTION must be send to activate)
+  /// \return True on success, false otherwise.
+  bool setTargetPosition(byte const &servoId, int const &position, int const &speed, bool const &asynchronous = false);
 
-	/// \brief Set target servo velocity.
-	/// \note This function assumes that the amplification factor ANGULAR_RESOLUTION is set to 1.
-	/// \param[in] servoId ID of the servo
-	/// \param[in] velocity Target velocity, in counts/s.
-	/// \param[in] asynchronous If set, write is asynchronous (ACTION must be send to activate)
-	/// \return True on success, false otherwise.
-	bool setTargetVelocity(byte const &servoId, int const &velocity, bool const &asynchronous = false);
+  /// \brief Set target servo velocity.
+  /// \note This function assumes that the amplification factor ANGULAR_RESOLUTION is set to 1.
+  /// \param[in] servoId ID of the servo
+  /// \param[in] velocity Target velocity, in counts/s.
+  /// \param[in] asynchronous If set, write is asynchronous (ACTION must be send to activate)
+  /// \return True on success, false otherwise.
+  bool setTargetVelocity(byte const &servoId, int const &velocity, bool const &asynchronous = false);
 
-	/// \brief Change the target acceleration of a servo.
-	/// \param[in] servoId servo ID
-	/// \param[in] acceleration target acceleration
-	/// \return True if servo could successfully set target acceleration
-	bool setTargetAcceleration(byte const &servoId, byte const &acceleration, bool const &asynchronous = false);
+  /// \brief Change the target acceleration of a servo.
+  /// \param[in] servoId servo ID
+  /// \param[in] acceleration target acceleration
+  /// \return True if servo could successfully set target acceleration
+  bool setTargetAcceleration(byte const &servoId, byte const &acceleration, bool const &asynchronous = false);
 
-	/// \brief Trigger the action previously stored by an asynchronous write on all servos.
-	/// \return True on success
-	bool trigerAction();
+  /// \brief Trigger the action previously stored by an asynchronous write on all servos.
+  /// \return True on success
+  bool trigerAction();
 
-	/// \brief Write to a single byte register.
-	/// \param[in] servoId ID of the servo
-	/// \param[in] registerId Register id.
-	/// \param[in] value Register value.
-	/// \param[in] asynchronous If set, write is asynchronous (ACTION must be send to activate)
-	/// \return True if write was successful
-	bool writeRegister(byte const &servoId,
-					   byte const &registerId,
-					   byte const &value,
-					   bool const &asynchronous = false);
+  /// \brief Write to a single byte register.
+  /// \param[in] servoId ID of the servo
+  /// \param[in] registerId Register id.
+  /// \param[in] value Register value.
+  /// \param[in] asynchronous If set, write is asynchronous (ACTION must be send to activate)
+  /// \return True if write was successful
+  bool writeRegister(byte const &servoId,
+                     byte const &registerId,
+                     byte const &value,
+                     bool const &asynchronous = false);
 
-	/// \brief Write a two-bytes register.
-	/// \param[in] servoId ID of the servo
-	/// \param[in] registerId Register id (LSB).
-	/// \param[in] value Register value.
-	/// \param[in] asynchronous If set, write is asynchronous (ACTION must be send to activate)
-	/// \return True if write was successful
-	bool writeTwoBytesRegister(byte const &servoId,
-							   byte const &registerId,
-							   int16_t const &value,
-							   bool const &asynchronous = false);
+  /// \brief Write a two-bytes register.
+  /// \param[in] servoId ID of the servo
+  /// \param[in] registerId Register id (LSB).
+  /// \param[in] value Register value.
+  /// \param[in] asynchronous If set, write is asynchronous (ACTION must be send to activate)
+  /// \return True if write was successful
+  bool writeTwoBytesRegister(byte const &servoId,
+                             byte const &registerId,
+                             int16_t const &value,
+                             bool const &asynchronous = false);
 
-	/// \brief Read a single register
-	/// \param[in] servoId ID of the servo
-	/// \param[in] registerId Register id.
-	/// \return Register value, 0 on failure.
-	byte readRegister(byte const &servoId, byte const &registerId);
+  /// \brief Read a single register
+  /// \param[in] servoId ID of the servo
+  /// \param[in] registerId Register id.
+  /// \return Register value, 0 on failure.
+  byte readRegister(byte const &servoId, byte const &registerId);
 
-	/// \brief Read two bytes, interpret result as <LSB> <MSB>
-	/// \param[in] servoId ID of the servo
-	/// \param[in] registerId LSB register id.
-	/// \return Register value, 0 on failure.
-	int16_t readTwoBytesRegister(byte const &servoId, byte const &registerId);
+  /// \brief Read two bytes, interpret result as <LSB> <MSB>
+  /// \param[in] servoId ID of the servo
+  /// \param[in] registerId LSB register id.
+  /// \return Register value, 0 on failure.
+  int16_t readTwoBytesRegister(byte const &servoId, byte const &registerId);
 
-	/// @brief Sets the target positions for multiple servos simultaneously.
-	/// @param[in] NumberOfServos Number of servo.
-	/// @param[in] servoIds Array of servo IDs to control.
-	/// @param[in] positions Array of target positions (corresponds to servoIds).
-	/// @param[in] speeds Array of target speeds (corresponds to servoIds).
-	void setTargetPositions(byte const &NumberOfServos,
-							const byte servoIds[],
-							const int positions[],
-							const int speeds[]);
+  /// @brief Sets the target positions for multiple servos simultaneously.
+  /// @param[in] NumberOfServos Number of servo.
+  /// @param[in] servoIds Array of servo IDs to control.
+  /// @param[in] positions Array of target positions (corresponds to servoIds).
+  /// @param[in] speeds Array of target speeds (corresponds to servoIds).
+  void setTargetPositions(byte const &NumberOfServos,
+                          const byte servoIds[],
+                          const int positions[],
+                          const int speeds[]);
 
 private:
-	/// \brief Clear internal device error.
-	// void clearError();
+  /// \brief Clear internal device error.
+  // void clearError();
 
-	/// \brief Send a message to the servos.
-	/// \param[in] servoId ID of the servo
-	/// \param[in] commandID Command id
-	/// \param[in] paramLength length of the parameters
-	/// \param[in] parameters parameters
-	/// \return Result of write.
-	int sendMessage(byte const &servoId,
-					byte const &commandID,
-					byte const &paramLength,
-					byte *parameters);
+  /// \brief Send a message to the servos.
+  /// \param[in] servoId ID of the servo
+  /// \param[in] commandID Command id
+  /// \param[in] paramLength length of the parameters
+  /// \param[in] parameters parameters
+  /// \return Result of write.
+  int sendMessage(byte const &servoId,
+                  byte const &commandID,
+                  byte const &paramLength,
+                  byte *parameters);
 
-	/// \brief Recieve a message from a given servo.
-	/// \param[in] servoId ID of the servo
-	/// \param[in] readLength Message length
-	/// \param[in] paramLength length of the parameters
-	/// \param[in] outputBuffer Buffer where the data is placed.
-	/// \return 0 on success
-	///         -1 if read failed due to timeout
-	///         -2 if invalid message (no 0XFF, wrong servo id)
-	///         -3 if invalid checksum
-	int recieveMessage(byte const &servoId,
-					   byte const &readLength,
-					   byte *outputBuffer);
+  /// \brief Recieve a message from a given servo.
+  /// \param[in] servoId ID of the servo
+  /// \param[in] readLength Message length
+  /// \param[in] paramLength length of the parameters
+  /// \param[in] outputBuffer Buffer where the data is placed.
+  /// \return 0 on success
+  ///         -1 if read failed due to timeout
+  ///         -2 if invalid message (no 0XFF, wrong servo id)
+  ///         -3 if invalid checksum
+  int recieveMessage(byte const &servoId,
+                     byte const &readLength,
+                     byte *outputBuffer);
 
-	/// \brief Write to a sequence of consecutive registers
-	/// \param[in] servoId ID of the servo
-	/// \param[in] startRegister First register
-	/// \param[in] writeLength Number of registers to write
-	/// \param[in] parameters Value of the registers
-	/// \param[in] asynchronous If set, write is asynchronous (ACTION must be send to activate)
-	/// \return True if write was successful
-	bool writeRegisters(byte const &servoId,
-						byte const &startRegister,
-						byte const &writeLength,
-						byte const *parameters,
-						bool const &asynchronous = false);
+  /// \brief Write to a sequence of consecutive registers
+  /// \param[in] servoId ID of the servo
+  /// \param[in] startRegister First register
+  /// \param[in] writeLength Number of registers to write
+  /// \param[in] parameters Value of the registers
+  /// \param[in] asynchronous If set, write is asynchronous (ACTION must be send to activate)
+  /// \return True if write was successful
+  bool writeRegisters(byte const &servoId,
+                      byte const &startRegister,
+                      byte const &writeLength,
+                      byte const *parameters,
+                      bool const &asynchronous = false);
 
-	/// \brief Read a sequence of consecutive registers.
-	/// \param[in] servoId ID of the servo
-	/// \param[in] startRegister First register
-	/// \param[in] readLength Number of registers to write
-	/// \param[out] outputBuffer Buffer where to read the data (must have been allocated by the user)
-	/// \return 0 on success, -1 if write failed, -2 if read failed, -3 if checksum verification failed
-	int readRegisters(byte const &servoId,
-					  byte const &startRegister,
-					  byte const &readLength,
-					  byte *outputBuffer);
+  /// \brief Read a sequence of consecutive registers.
+  /// \param[in] servoId ID of the servo
+  /// \param[in] startRegister First register
+  /// \param[in] readLength Number of registers to write
+  /// \param[out] outputBuffer Buffer where to read the data (must have been allocated by the user)
+  /// \return 0 on success, -1 if write failed, -2 if read failed, -3 if checksum verification failed
+  int readRegisters(byte const &servoId,
+                    byte const &startRegister,
+                    byte const &readLength,
+                    byte *outputBuffer);
 
-	/// @brief Send two bytes and update checksum
-	/// @param[in] convertedValue Converted int value
-	/// @param[out] checksum Update the checksum
-	void sendAndUpdateChecksum(byte convertedValue[], byte &checksum);
+  /// @brief Send two bytes and update checksum
+  /// @param[in] convertedValue Converted int value
+  /// @param[out] checksum Update the checksum
+  void sendAndUpdateChecksum(byte convertedValue[], byte &checksum);
 
-	/// @brief Convert int to pair of bytes
-	/// @param[in] value
-	/// @param[out] result
-	void convertIntToBytes(int const &value, byte result[2]);
+  /// @brief Convert int to pair of bytes
+  /// @param[in] value
+  /// @param[out] result
+  void convertIntToBytes(int const &value, byte result[2]);
 
-	HardwareSerial *port_;
-	byte dirPin_; ///< Direction pin number.
+  HardwareSerial *port_;
+  byte dirPin_; ///< Direction pin number.
 };
 #endif

--- a/src/STSServoDriver.h
+++ b/src/STSServoDriver.h
@@ -176,9 +176,9 @@ public:
     /// @param[in] servoIds Array of servo IDs to control.
     /// @param[in] positions Array of target positions (corresponds to servoIds).
     /// @param[in] speeds Array of target speeds (corresponds to servoIds).
-    void setTargetPositions(byte servoIds[],
-                            int positions[],
-                            int speeds[]);
+    void setTargetPositions(const byte servoIds[],
+                            const int positions[],
+                            const int speeds[]);
 
 private:
     /// \brief Clear internal device error.

--- a/src/STSServoDriver.h
+++ b/src/STSServoDriver.h
@@ -13,250 +13,250 @@
 
 namespace STSRegisters
 {
-  byte const FIRMWARE_MAJOR           = 0x00;
-  byte const FIRMWARE_MINOR           = 0x01;
-  byte const SERVO_MAJOR              = 0x03;
-  byte const SERVO_MINOR              = 0x04;
-  byte const ID                       = 0x05;
-  byte const BAUDRATE                 = 0x06;
-  byte const RESPONSE_DELAY           = 0x07;
-  byte const RESPONSE_STATUS_LEVEL    = 0x08;
-  byte const MINIMUM_ANGLE            = 0x09;
-  byte const MAXIMUM_ANGLE            = 0x0B;
-  byte const MAXIMUM_TEMPERATURE      = 0x0D;
-  byte const MAXIMUM_VOLTAGE          = 0x0E;
-  byte const MINIMUM_VOLTAGE          = 0x0F;
-  byte const MAXIMUM_TORQUE           = 0x10;
-  byte const UNLOADING_CONDITION      = 0x13;
-  byte const LED_ALARM_CONDITION      = 0x14;
-  byte const POS_PROPORTIONAL_GAIN    = 0x15;
-  byte const POS_DERIVATIVE_GAIN      = 0x16;
-  byte const POS_INTEGRAL_GAIN        = 0x17;
-  byte const MINIMUM_STARTUP_FORCE    = 0x18;
-  byte const CK_INSENSITIVE_AREA      = 0x1A;
-  byte const CCK_INSENSITIVE_AREA     = 0x1B;
-  byte const CURRENT_PROTECTION_TH    = 0x1C;
-  byte const ANGULAR_RESOLUTION       = 0x1E;
-  byte const POSITION_CORRECTION      = 0x1F;
-  byte const OPERATION_MODE           = 0x21;
-  byte const TORQUE_PROTECTION_TH     = 0x22;
-  byte const TORQUE_PROTECTION_TIME   = 0x23;
-  byte const OVERLOAD_TORQUE          = 0x24;
-  byte const SPEED_PROPORTIONAL_GAIN  = 0x25;
-  byte const OVERCURRENT_TIME         = 0x26;
-  byte const SPEED_INTEGRAL_GAIN      = 0x27;
-  byte const TORQUE_SWITCH            = 0x28;
-  byte const TARGET_ACCELERATION      = 0x29;
-  byte const TARGET_POSITION          = 0x2A;
-  byte const RUNNING_TIME             = 0x2C;
-  byte const RUNNING_SPEED            = 0x2E;
-  byte const TORQUE_LIMIT             = 0x30;
-  byte const WRITE_LOCK               = 0x37;
-  byte const CURRENT_POSITION         = 0x38;
-  byte const CURRENT_SPEED            = 0x3A;
-  byte const CURRENT_DRIVE_VOLTAGE    = 0x3C;
-  byte const CURRENT_VOLTAGE          = 0x3E;
-  byte const CURRENT_TEMPERATURE      = 0x3F;
-  byte const ASYNCHRONOUS_WRITE_ST    = 0x40;
-  byte const STATUS                   = 0x41;
-  byte const MOVING_STATUS            = 0x42;
-  byte const CURRENT_CURRENT          = 0x45;
+    byte const FIRMWARE_MAJOR           = 0x00;
+    byte const FIRMWARE_MINOR           = 0x01;
+    byte const SERVO_MAJOR              = 0x03;
+    byte const SERVO_MINOR              = 0x04;
+    byte const ID                       = 0x05;
+    byte const BAUDRATE                 = 0x06;
+    byte const RESPONSE_DELAY           = 0x07;
+    byte const RESPONSE_STATUS_LEVEL    = 0x08;
+    byte const MINIMUM_ANGLE            = 0x09;
+    byte const MAXIMUM_ANGLE            = 0x0B;
+    byte const MAXIMUM_TEMPERATURE      = 0x0D;
+    byte const MAXIMUM_VOLTAGE          = 0x0E;
+    byte const MINIMUM_VOLTAGE          = 0x0F;
+    byte const MAXIMUM_TORQUE           = 0x10;
+    byte const UNLOADING_CONDITION      = 0x13;
+    byte const LED_ALARM_CONDITION      = 0x14;
+    byte const POS_PROPORTIONAL_GAIN    = 0x15;
+    byte const POS_DERIVATIVE_GAIN      = 0x16;
+    byte const POS_INTEGRAL_GAIN        = 0x17;
+    byte const MINIMUM_STARTUP_FORCE    = 0x18;
+    byte const CK_INSENSITIVE_AREA      = 0x1A;
+    byte const CCK_INSENSITIVE_AREA     = 0x1B;
+    byte const CURRENT_PROTECTION_TH    = 0x1C;
+    byte const ANGULAR_RESOLUTION       = 0x1E;
+    byte const POSITION_CORRECTION      = 0x1F;
+    byte const OPERATION_MODE           = 0x21;
+    byte const TORQUE_PROTECTION_TH     = 0x22;
+    byte const TORQUE_PROTECTION_TIME   = 0x23;
+    byte const OVERLOAD_TORQUE          = 0x24;
+    byte const SPEED_PROPORTIONAL_GAIN  = 0x25;
+    byte const OVERCURRENT_TIME         = 0x26;
+    byte const SPEED_INTEGRAL_GAIN      = 0x27;
+    byte const TORQUE_SWITCH            = 0x28;
+    byte const TARGET_ACCELERATION      = 0x29;
+    byte const TARGET_POSITION          = 0x2A;
+    byte const RUNNING_TIME             = 0x2C;
+    byte const RUNNING_SPEED            = 0x2E;
+    byte const TORQUE_LIMIT             = 0x30;
+    byte const WRITE_LOCK               = 0x37;
+    byte const CURRENT_POSITION         = 0x38;
+    byte const CURRENT_SPEED            = 0x3A;
+    byte const CURRENT_DRIVE_VOLTAGE    = 0x3C;
+    byte const CURRENT_VOLTAGE          = 0x3E;
+    byte const CURRENT_TEMPERATURE      = 0x3F;
+    byte const ASYNCHRONOUS_WRITE_ST    = 0x40;
+    byte const STATUS                   = 0x41;
+    byte const MOVING_STATUS            = 0x42;
+    byte const CURRENT_CURRENT          = 0x45;
 };
 
 /// \brief Driver for STS servos, using UART
 class STSServoDriver
 {
 public:
-  /// \brief Contstructor.
-  STSServoDriver();
+    /// \brief Contstructor.
+    STSServoDriver();
 
-  /// \brief Initialize the servo driver.
-  ///
-  /// \param dirPin Pin used for setting communication direction
-  /// \param serialPort Serial port, default is Serial
-  /// \param baudRate Baud rate, default 1Mbps
-  /// \returns  True on success (at least one servo responds to ping)
-  bool init(byte const &dirPin, HardwareSerial *serialPort = nullptr, long const &baudRate = 1000000);
+    /// \brief Initialize the servo driver.
+    ///
+    /// \param dirPin Pin used for setting communication direction
+    /// \param serialPort Serial port, default is Serial
+    /// \param baudRate Baud rate, default 1Mbps
+    /// \returns  True on success (at least one servo responds to ping)
+    bool init(byte const &dirPin, HardwareSerial *serialPort = nullptr, long const &baudRate = 1000000);
 
-  /// \brief Ping servo
-  /// \param[in] servoId ID of the servo
-  /// \return True if servo responded to ping
-  bool ping(byte const &servoId);
+    /// \brief Ping servo
+    /// \param[in] servoId ID of the servo
+    /// \return True if servo responded to ping
+    bool ping(byte const &servoId);
 
-  /// \brief Change the ID of a servo.
-  /// \note If the desired ID is already taken, this function does nothing and returns false.
-  /// \param[in] oldServoId old servo ID
-  /// \param[in] newServoId new servo ID
-  /// \return True if servo could successfully change ID
-  bool setId(byte const &oldServoId, byte const &newServoId);
+    /// \brief Change the ID of a servo.
+    /// \note If the desired ID is already taken, this function does nothing and returns false.
+    /// \param[in] oldServoId old servo ID
+    /// \param[in] newServoId new servo ID
+    /// \return True if servo could successfully change ID
+    bool setId(byte const &oldServoId, byte const &newServoId);
 
-  /// \brief Change the position offset of a servo.
-  /// \param[in] servoId servo ID
-  /// \param[in] positionOffset new position offset
-  /// \return True if servo could successfully change position offset
-  bool setPositionOffset(byte const &servoId, int const &positionOffset);
+    /// \brief Change the position offset of a servo.
+    /// \param[in] servoId servo ID
+    /// \param[in] positionOffset new position offset
+    /// \return True if servo could successfully change position offset
+    bool setPositionOffset(byte const &servoId, int const &positionOffset);
 
-  /// \brief Get current servo position.
-  /// \note This function assumes that the amplification factor ANGULAR_RESOLUTION is set to 1.
-  /// \param[in] servoId ID of the servo
-  /// \return Position, in counts. 0 on failure.
-  int getCurrentPosition(byte const &servoId);
+    /// \brief Get current servo position.
+    /// \note This function assumes that the amplification factor ANGULAR_RESOLUTION is set to 1.
+    /// \param[in] servoId ID of the servo
+    /// \return Position, in counts. 0 on failure.
+    int getCurrentPosition(byte const &servoId);
 
-  /// \brief Get current servo speed.
-  /// \note This function assumes that the amplification factor ANGULAR_RESOLUTION is set to 1.
-  /// \param[in] servoId ID of the servo
-  /// \return Speed, in counts/s. 0 on failure.
-  int getCurrentSpeed(byte const &servoId);
+    /// \brief Get current servo speed.
+    /// \note This function assumes that the amplification factor ANGULAR_RESOLUTION is set to 1.
+    /// \param[in] servoId ID of the servo
+    /// \return Speed, in counts/s. 0 on failure.
+    int getCurrentSpeed(byte const &servoId);
 
-  /// \brief Get current servo temperature.
-  /// \param[in] servoId ID of the servo
-  /// \return Temperature, in degC. 0 on failure.
-  int getCurrentTemperature(byte const &servoId);
+    /// \brief Get current servo temperature.
+    /// \param[in] servoId ID of the servo
+    /// \return Temperature, in degC. 0 on failure.
+    int getCurrentTemperature(byte const &servoId);
 
-  /// \brief Get current servo current.
-  /// \param[in] servoId ID of the servo
-  /// \return Current, in A.
-  int getCurrentCurrent(byte const &servoId);
+    /// \brief Get current servo current.
+    /// \param[in] servoId ID of the servo
+    /// \return Current, in A.
+    int getCurrentCurrent(byte const &servoId);
 
-  /// \brief Check if the servo is moving
-  /// \param[in] servoId ID of the servo
-  /// \return True if moving, false otherwise.
-  bool isMoving(byte const &servoId);
+    /// \brief Check if the servo is moving
+    /// \param[in] servoId ID of the servo
+    /// \return True if moving, false otherwise.
+    bool isMoving(byte const &servoId);
 
-  /// \brief Set target servo position.
-  /// \note This function assumes that the amplification factor ANGULAR_RESOLUTION is set to 1.
-  /// \param[in] servoId ID of the servo
-  /// \param[in] position Target position, in counts.
-  /// \param[in] speed speed of the servo.
-  /// \param[in] asynchronous If set, write is asynchronous (ACTION must be send to activate)
-  /// \return True on success, false otherwise.
-  bool setTargetPosition(byte const &servoId, int const &position, int const &speed, bool const &asynchronous = false);
+    /// \brief Set target servo position.
+    /// \note This function assumes that the amplification factor ANGULAR_RESOLUTION is set to 1.
+    /// \param[in] servoId ID of the servo
+    /// \param[in] position Target position, in counts.
+    /// \param[in] speed speed of the servo.
+    /// \param[in] asynchronous If set, write is asynchronous (ACTION must be send to activate)
+    /// \return True on success, false otherwise.
+    bool setTargetPosition(byte const &servoId, int const &position, int const &speed, bool const &asynchronous = false);
 
-  /// \brief Set target servo velocity.
-  /// \note This function assumes that the amplification factor ANGULAR_RESOLUTION is set to 1.
-  /// \param[in] servoId ID of the servo
-  /// \param[in] velocity Target velocity, in counts/s.
-  /// \param[in] asynchronous If set, write is asynchronous (ACTION must be send to activate)
-  /// \return True on success, false otherwise.
-  bool setTargetVelocity(byte const &servoId, int const &velocity, bool const &asynchronous = false);
+    /// \brief Set target servo velocity.
+    /// \note This function assumes that the amplification factor ANGULAR_RESOLUTION is set to 1.
+    /// \param[in] servoId ID of the servo
+    /// \param[in] velocity Target velocity, in counts/s.
+    /// \param[in] asynchronous If set, write is asynchronous (ACTION must be send to activate)
+    /// \return True on success, false otherwise.
+    bool setTargetVelocity(byte const &servoId, int const &velocity, bool const &asynchronous = false);
 
-  /// \brief Change the target acceleration of a servo.
-  /// \param[in] servoId servo ID
-  /// \param[in] acceleration target acceleration
-  /// \return True if servo could successfully set target acceleration
-  bool setTargetAcceleration(byte const &servoId, byte const &acceleration, bool const &asynchronous = false);
+    /// \brief Change the target acceleration of a servo.
+    /// \param[in] servoId servo ID
+    /// \param[in] acceleration target acceleration
+    /// \return True if servo could successfully set target acceleration
+    bool setTargetAcceleration(byte const &servoId, byte const &acceleration, bool const &asynchronous = false);
 
-  /// \brief Trigger the action previously stored by an asynchronous write on all servos.
-  /// \return True on success
-  bool trigerAction();
+    /// \brief Trigger the action previously stored by an asynchronous write on all servos.
+    /// \return True on success
+    bool trigerAction();
 
-  /// \brief Write to a single byte register.
-  /// \param[in] servoId ID of the servo
-  /// \param[in] registerId Register id.
-  /// \param[in] value Register value.
-  /// \param[in] asynchronous If set, write is asynchronous (ACTION must be send to activate)
-  /// \return True if write was successful
-  bool writeRegister(byte const &servoId,
-                     byte const &registerId,
-                     byte const &value,
-                     bool const &asynchronous = false);
+    /// \brief Write to a single byte register.
+    /// \param[in] servoId ID of the servo
+    /// \param[in] registerId Register id.
+    /// \param[in] value Register value.
+    /// \param[in] asynchronous If set, write is asynchronous (ACTION must be send to activate)
+    /// \return True if write was successful
+    bool writeRegister(byte const &servoId,
+                       byte const &registerId,
+                       byte const &value,
+                       bool const &asynchronous = false);
 
-  /// \brief Write a two-bytes register.
-  /// \param[in] servoId ID of the servo
-  /// \param[in] registerId Register id (LSB).
-  /// \param[in] value Register value.
-  /// \param[in] asynchronous If set, write is asynchronous (ACTION must be send to activate)
-  /// \return True if write was successful
-  bool writeTwoBytesRegister(byte const &servoId,
-                             byte const &registerId,
-                             int16_t const &value,
-                             bool const &asynchronous = false);
+    /// \brief Write a two-bytes register.
+    /// \param[in] servoId ID of the servo
+    /// \param[in] registerId Register id (LSB).
+    /// \param[in] value Register value.
+    /// \param[in] asynchronous If set, write is asynchronous (ACTION must be send to activate)
+    /// \return True if write was successful
+    bool writeTwoBytesRegister(byte const &servoId,
+                               byte const &registerId,
+                               int16_t const &value,
+                               bool const &asynchronous = false);
 
-  /// \brief Read a single register
-  /// \param[in] servoId ID of the servo
-  /// \param[in] registerId Register id.
-  /// \return Register value, 0 on failure.
-  byte readRegister(byte const &servoId, byte const &registerId);
+    /// \brief Read a single register
+    /// \param[in] servoId ID of the servo
+    /// \param[in] registerId Register id.
+    /// \return Register value, 0 on failure.
+    byte readRegister(byte const &servoId, byte const &registerId);
 
-  /// \brief Read two bytes, interpret result as <LSB> <MSB>
-  /// \param[in] servoId ID of the servo
-  /// \param[in] registerId LSB register id.
-  /// \return Register value, 0 on failure.
-  int16_t readTwoBytesRegister(byte const &servoId, byte const &registerId);
+    /// \brief Read two bytes, interpret result as <LSB> <MSB>
+    /// \param[in] servoId ID of the servo
+    /// \param[in] registerId LSB register id.
+    /// \return Register value, 0 on failure.
+    int16_t readTwoBytesRegister(byte const &servoId, byte const &registerId);
 
-  /// @brief Sets the target positions for multiple servos simultaneously.
-  /// @param[in] NumberOfServos Number of servo.
-  /// @param[in] servoIds Array of servo IDs to control.
-  /// @param[in] positions Array of target positions (corresponds to servoIds).
-  /// @param[in] speeds Array of target speeds (corresponds to servoIds).
-  void setTargetPositions(byte const &NumberOfServos,
-                          const byte servoIds[],
-                          const int positions[],
-                          const int speeds[]);
+    /// @brief Sets the target positions for multiple servos simultaneously.
+    /// @param[in] NumberOfServos Number of servo.
+    /// @param[in] servoIds Array of servo IDs to control.
+    /// @param[in] positions Array of target positions (corresponds to servoIds).
+    /// @param[in] speeds Array of target speeds (corresponds to servoIds).
+    void setTargetPositions(byte const &NumberOfServos,
+                            const byte servoIds[],
+                            const int positions[],
+                            const int speeds[]);
 
 private:
-  /// \brief Clear internal device error.
-  // void clearError();
+    /// \brief Clear internal device error.
+    // void clearError();
 
-  /// \brief Send a message to the servos.
-  /// \param[in] servoId ID of the servo
-  /// \param[in] commandID Command id
-  /// \param[in] paramLength length of the parameters
-  /// \param[in] parameters parameters
-  /// \return Result of write.
-  int sendMessage(byte const &servoId,
-                  byte const &commandID,
-                  byte const &paramLength,
-                  byte *parameters);
+    /// \brief Send a message to the servos.
+    /// \param[in] servoId ID of the servo
+    /// \param[in] commandID Command id
+    /// \param[in] paramLength length of the parameters
+    /// \param[in] parameters parameters
+    /// \return Result of write.
+    int sendMessage(byte const &servoId,
+                    byte const &commandID,
+                    byte const &paramLength,
+                    byte *parameters);
 
-  /// \brief Recieve a message from a given servo.
-  /// \param[in] servoId ID of the servo
-  /// \param[in] readLength Message length
-  /// \param[in] paramLength length of the parameters
-  /// \param[in] outputBuffer Buffer where the data is placed.
-  /// \return 0 on success
-  ///         -1 if read failed due to timeout
-  ///         -2 if invalid message (no 0XFF, wrong servo id)
-  ///         -3 if invalid checksum
-  int recieveMessage(byte const &servoId,
-                     byte const &readLength,
-                     byte *outputBuffer);
+    /// \brief Recieve a message from a given servo.
+    /// \param[in] servoId ID of the servo
+    /// \param[in] readLength Message length
+    /// \param[in] paramLength length of the parameters
+    /// \param[in] outputBuffer Buffer where the data is placed.
+    /// \return 0 on success
+    ///         -1 if read failed due to timeout
+    ///         -2 if invalid message (no 0XFF, wrong servo id)
+    ///         -3 if invalid checksum
+    int recieveMessage(byte const &servoId,
+                       byte const &readLength,
+                       byte *outputBuffer);
 
-  /// \brief Write to a sequence of consecutive registers
-  /// \param[in] servoId ID of the servo
-  /// \param[in] startRegister First register
-  /// \param[in] writeLength Number of registers to write
-  /// \param[in] parameters Value of the registers
-  /// \param[in] asynchronous If set, write is asynchronous (ACTION must be send to activate)
-  /// \return True if write was successful
-  bool writeRegisters(byte const &servoId,
+    /// \brief Write to a sequence of consecutive registers
+    /// \param[in] servoId ID of the servo
+    /// \param[in] startRegister First register
+    /// \param[in] writeLength Number of registers to write
+    /// \param[in] parameters Value of the registers
+    /// \param[in] asynchronous If set, write is asynchronous (ACTION must be send to activate)
+    /// \return True if write was successful
+    bool writeRegisters(byte const &servoId,
+                        byte const &startRegister,
+                        byte const &writeLength,
+                        byte const *parameters,
+                        bool const &asynchronous = false);
+
+    /// \brief Read a sequence of consecutive registers.
+    /// \param[in] servoId ID of the servo
+    /// \param[in] startRegister First register
+    /// \param[in] readLength Number of registers to write
+    /// \param[out] outputBuffer Buffer where to read the data (must have been allocated by the user)
+    /// \return 0 on success, -1 if write failed, -2 if read failed, -3 if checksum verification failed
+    int readRegisters(byte const &servoId,
                       byte const &startRegister,
-                      byte const &writeLength,
-                      byte const *parameters,
-                      bool const &asynchronous = false);
+                      byte const &readLength,
+                      byte *outputBuffer);
 
-  /// \brief Read a sequence of consecutive registers.
-  /// \param[in] servoId ID of the servo
-  /// \param[in] startRegister First register
-  /// \param[in] readLength Number of registers to write
-  /// \param[out] outputBuffer Buffer where to read the data (must have been allocated by the user)
-  /// \return 0 on success, -1 if write failed, -2 if read failed, -3 if checksum verification failed
-  int readRegisters(byte const &servoId,
-                    byte const &startRegister,
-                    byte const &readLength,
-                    byte *outputBuffer);
+    /// @brief Send two bytes and update checksum
+    /// @param[in] convertedValue Converted int value
+    /// @param[out] checksum Update the checksum
+    void sendAndUpdateChecksum(byte convertedValue[], byte &checksum);
 
-  /// @brief Send two bytes and update checksum
-  /// @param[in] convertedValue Converted int value
-  /// @param[out] checksum Update the checksum
-  void sendAndUpdateChecksum(byte convertedValue[], byte &checksum);
+    /// @brief Convert int to pair of bytes
+    /// @param[in] value
+    /// @param[out] result
+    void convertIntToBytes(int const &value, byte result[2]);
 
-  /// @brief Convert int to pair of bytes
-  /// @param[in] value
-  /// @param[out] result
-  void convertIntToBytes(int const &value, byte result[2]);
-
-  HardwareSerial *port_;
-  byte dirPin_; ///< Direction pin number.
+    HardwareSerial *port_;
+    byte dirPin_; ///< Direction pin number.
 };
 #endif

--- a/src/STSServoDriver.h
+++ b/src/STSServoDriver.h
@@ -90,11 +90,11 @@ public:
 	/// \return True if servo could successfully change ID
 	bool setId(byte const &oldServoId, byte const &newServoId);
 
-	/// \brief Change the goal acceleration of a servo.
+	/// \brief Change the position offset of a servo.
 	/// \param[in] servoId servo ID
-	/// \param[in] acceleration goal acceleration
-	/// \return True if servo could successfully set goal acceleration
-	bool setGoalAcceleration(byte const &servoId, byte const &acceleration)
+	/// \param[in] positionOffset new position offset
+	/// \return True if servo could successfully change position offset
+	bool setPositionOffset(byte const &servoId, int const &positionOffset);
 
 	/// \brief Get current servo position.
 	/// \note This function assumes that the amplification factor ANGULAR_RESOLUTION is set to 1.
@@ -139,6 +139,12 @@ public:
 	/// \param[in] asynchronous If set, write is asynchronous (ACTION must be send to activate)
 	/// \return True on success, false otherwise.
 	bool setTargetVelocity(byte const &servoId, int const &velocity, bool const &asynchronous = false);
+
+	/// \brief Change the target acceleration of a servo.
+	/// \param[in] servoId servo ID
+	/// \param[in] acceleration target acceleration
+	/// \return True if servo could successfully set target acceleration
+	bool setTargetAcceleration(byte const &servoId, byte const &acceleration, bool const &asynchronous = false);
 
 	/// \brief Trigger the action previously stored by an asynchronous write on all servos.
 	/// \return True on success

--- a/src/STSServoDriver.h
+++ b/src/STSServoDriver.h
@@ -121,9 +121,10 @@ public:
     /// \note This function assumes that the amplification factor ANGULAR_RESOLUTION is set to 1.
     /// \param[in] servoId ID of the servo
     /// \param[in] position Target position, in counts.
+    /// \param[in] speed speed of the servo.
     /// \param[in] asynchronous If set, write is asynchronous (ACTION must be send to activate)
     /// \return True on success, false otherwise.
-    bool setTargetPosition(byte const &servoId, int const &position, bool const &asynchronous = false);
+    bool setTargetPosition(byte const &servoId, int const &position, int const &speed, bool const &asynchronous = false);
 
     /// \brief Set target servo velocity.
     /// \note This function assumes that the amplification factor ANGULAR_RESOLUTION is set to 1.
@@ -175,9 +176,9 @@ public:
     /// @param[in] servoIds Array of servo IDs to control.
     /// @param[in] positions Array of target positions (corresponds to servoIds).
     /// @param[in] speeds Array of target speeds (corresponds to servoIds).
-    void setTargetPositions(byte  servoIds[],
-                           int  positions[], 
-                           int  speeds[]);
+    void setTargetPositions(byte servoIds[],
+                            int positions[],
+                            int speeds[]);
 
 private:
     /// \brief Clear internal device error.
@@ -231,14 +232,14 @@ private:
                       byte const &readLength,
                       byte *outputBuffer);
 
-    /// @brief Send two bytes and update checksum  
-    /// @param[in] convertedValue Converted int value 
-    /// @param[out] checksum Update the checksum 
+    /// @brief Send two bytes and update checksum
+    /// @param[in] convertedValue Converted int value
+    /// @param[out] checksum Update the checksum
     void sendAndUpdateChecksum(byte convertedValue[], byte &checksum);
 
     /// @brief Convert int to pair of bytes
-    /// @param[in] value 
-    /// @param[out] result 
+    /// @param[in] value
+    /// @param[out] result
     void convertIntToBytes(int const &value, byte result[2]);
 
     HardwareSerial *port_;

--- a/src/STSServoDriver.h
+++ b/src/STSServoDriver.h
@@ -13,236 +13,238 @@
 
 namespace STSRegisters
 {
-    byte const FIRMWARE_MAJOR = 0x00;
-    byte const FIRMWARE_MINOR = 0x01;
-    byte const SERVO_MAJOR = 0x03;
-    byte const SERVO_MINOR = 0x04;
-    byte const ID = 0x05;
-    byte const BAUDRATE = 0x06;
-    byte const RESPONSE_DELAY = 0x07;
-    byte const RESPONSE_STATUS_LEVEL = 0x08;
-    byte const MINIMUM_ANGLE = 0x09;
-    byte const MAXIMUM_ANGLE = 0x0B;
-    byte const MAXIMUM_TEMPERATURE = 0x0D;
-    byte const MAXIMUM_VOLTAGE = 0x0E;
-    byte const MINIMUM_VOLTAGE = 0x0F;
-    byte const MAXIMUM_TORQUE = 0x10;
-    byte const UNLOADING_CONDITION = 0x13;
-    byte const LED_ALARM_CONDITION = 0x14;
-    byte const POS_PROPORTIONAL_GAIN = 0x15;
-    byte const POS_DERIVATIVE_GAIN = 0x16;
-    byte const POS_INTEGRAL_GAIN = 0x17;
-    byte const MINIMUM_STARTUP_FORCE = 0x18;
-    byte const CK_INSENSITIVE_AREA = 0x1A;
-    byte const CCK_INSENSITIVE_AREA = 0x1B;
-    byte const CURRENT_PROTECTION_TH = 0x1C;
-    byte const ANGULAR_RESOLUTION = 0x1E;
-    byte const POSITION_CORRECTION = 0x1F;
-    byte const OPERATION_MODE = 0x21;
-    byte const TORQUE_PROTECTION_TH = 0x22;
-    byte const TORQUE_PROTECTION_TIME = 0x23;
-    byte const OVERLOAD_TORQUE = 0x24;
-    byte const SPEED_PROPORTIONAL_GAIN = 0x25;
-    byte const OVERCURRENT_TIME = 0x26;
-    byte const SPEED_INTEGRAL_GAIN = 0x27;
-    byte const TORQUE_SWITCH = 0x28;
-    byte const TARGET_ACCELERATION = 0x29;
-    byte const TARGET_POSITION = 0x2A;
-    byte const RUNNING_TIME = 0x2C;
-    byte const RUNNING_SPEED = 0x2E;
-    byte const TORQUE_LIMIT = 0x30;
-    byte const WRITE_LOCK = 0x37;
-    byte const CURRENT_POSITION = 0x38;
-    byte const CURRENT_SPEED = 0x3A;
-    byte const CURRENT_DRIVE_VOLTAGE = 0x3C;
-    byte const CURRENT_VOLTAGE = 0x3E;
-    byte const CURRENT_TEMPERATURE = 0x3F;
-    byte const ASYNCHRONOUS_WRITE_ST = 0x40;
-    byte const STATUS = 0x41;
-    byte const MOVING_STATUS = 0x42;
-    byte const CURRENT_CURRENT = 0x45;
+	byte const FIRMWARE_MAJOR = 0x00;
+	byte const FIRMWARE_MINOR = 0x01;
+	byte const SERVO_MAJOR = 0x03;
+	byte const SERVO_MINOR = 0x04;
+	byte const ID = 0x05;
+	byte const BAUDRATE = 0x06;
+	byte const RESPONSE_DELAY = 0x07;
+	byte const RESPONSE_STATUS_LEVEL = 0x08;
+	byte const MINIMUM_ANGLE = 0x09;
+	byte const MAXIMUM_ANGLE = 0x0B;
+	byte const MAXIMUM_TEMPERATURE = 0x0D;
+	byte const MAXIMUM_VOLTAGE = 0x0E;
+	byte const MINIMUM_VOLTAGE = 0x0F;
+	byte const MAXIMUM_TORQUE = 0x10;
+	byte const UNLOADING_CONDITION = 0x13;
+	byte const LED_ALARM_CONDITION = 0x14;
+	byte const POS_PROPORTIONAL_GAIN = 0x15;
+	byte const POS_DERIVATIVE_GAIN = 0x16;
+	byte const POS_INTEGRAL_GAIN = 0x17;
+	byte const MINIMUM_STARTUP_FORCE = 0x18;
+	byte const CK_INSENSITIVE_AREA = 0x1A;
+	byte const CCK_INSENSITIVE_AREA = 0x1B;
+	byte const CURRENT_PROTECTION_TH = 0x1C;
+	byte const ANGULAR_RESOLUTION = 0x1E;
+	byte const POSITION_CORRECTION = 0x1F;
+	byte const OPERATION_MODE = 0x21;
+	byte const TORQUE_PROTECTION_TH = 0x22;
+	byte const TORQUE_PROTECTION_TIME = 0x23;
+	byte const OVERLOAD_TORQUE = 0x24;
+	byte const SPEED_PROPORTIONAL_GAIN = 0x25;
+	byte const OVERCURRENT_TIME = 0x26;
+	byte const SPEED_INTEGRAL_GAIN = 0x27;
+	byte const TORQUE_SWITCH = 0x28;
+	byte const TARGET_ACCELERATION = 0x29;
+	byte const TARGET_POSITION = 0x2A;
+	byte const RUNNING_TIME = 0x2C;
+	byte const RUNNING_SPEED = 0x2E;
+	byte const TORQUE_LIMIT = 0x30;
+	byte const WRITE_LOCK = 0x37;
+	byte const CURRENT_POSITION = 0x38;
+	byte const CURRENT_SPEED = 0x3A;
+	byte const CURRENT_DRIVE_VOLTAGE = 0x3C;
+	byte const CURRENT_VOLTAGE = 0x3E;
+	byte const CURRENT_TEMPERATURE = 0x3F;
+	byte const ASYNCHRONOUS_WRITE_ST = 0x40;
+	byte const STATUS = 0x41;
+	byte const MOVING_STATUS = 0x42;
+	byte const CURRENT_CURRENT = 0x45;
 };
 
 /// \brief Driver for STS servos, using UART
 class STSServoDriver
 {
 public:
-    /// \brief Contstructor.
-    STSServoDriver();
+	/// \brief Contstructor.
+	STSServoDriver();
 
-    /// \brief Initialize the servo driver.
-    ///
-    /// \param dirPin Pin used for setting communication direction
-    /// \param serialPort Serial port, default is Serial
-    /// \param baudRate Baud rate, default 1Mbps
-    /// \returns  True on success (at least one servo responds to ping)
-    bool init(byte const &dirPin, HardwareSerial *serialPort = nullptr, long const &baudRate = 1000000);
+	/// \brief Initialize the servo driver.
+	///
+	/// \param dirPin Pin used for setting communication direction
+	/// \param serialPort Serial port, default is Serial
+	/// \param baudRate Baud rate, default 1Mbps
+	/// \returns  True on success (at least one servo responds to ping)
+	bool init(byte const &dirPin, HardwareSerial *serialPort = nullptr, long const &baudRate = 1000000);
 
-    /// \brief Ping servo
-    /// \param[in] servoId ID of the servo
-    /// \return True if servo responded to ping
-    bool ping(byte const &servoId);
+	/// \brief Ping servo
+	/// \param[in] servoId ID of the servo
+	/// \return True if servo responded to ping
+	bool ping(byte const &servoId);
 
-    /// \brief Change the ID of a servo.
-    /// \note If the desired ID is already taken, this function does nothing and returns false.
-    /// \param[in] oldServoId old servo ID
-    /// \param[in] newServoId new servo ID
-    /// \return True if servo could successfully change ID
-    bool setId(byte const &oldServoId, byte const &newServoId);
+	/// \brief Change the ID of a servo.
+	/// \note If the desired ID is already taken, this function does nothing and returns false.
+	/// \param[in] oldServoId old servo ID
+	/// \param[in] newServoId new servo ID
+	/// \return True if servo could successfully change ID
+	bool setId(byte const &oldServoId, byte const &newServoId);
 
-    /// \brief Get current servo position.
-    /// \note This function assumes that the amplification factor ANGULAR_RESOLUTION is set to 1.
-    /// \param[in] servoId ID of the servo
-    /// \return Position, in counts. 0 on failure.
-    int getCurrentPosition(byte const &servoId);
+	/// \brief Get current servo position.
+	/// \note This function assumes that the amplification factor ANGULAR_RESOLUTION is set to 1.
+	/// \param[in] servoId ID of the servo
+	/// \return Position, in counts. 0 on failure.
+	int getCurrentPosition(byte const &servoId);
 
-    /// \brief Get current servo speed.
-    /// \note This function assumes that the amplification factor ANGULAR_RESOLUTION is set to 1.
-    /// \param[in] servoId ID of the servo
-    /// \return Speed, in counts/s. 0 on failure.
-    int getCurrentSpeed(byte const &servoId);
+	/// \brief Get current servo speed.
+	/// \note This function assumes that the amplification factor ANGULAR_RESOLUTION is set to 1.
+	/// \param[in] servoId ID of the servo
+	/// \return Speed, in counts/s. 0 on failure.
+	int getCurrentSpeed(byte const &servoId);
 
-    /// \brief Get current servo temperature.
-    /// \param[in] servoId ID of the servo
-    /// \return Temperature, in degC. 0 on failure.
-    int getCurrentTemperature(byte const &servoId);
+	/// \brief Get current servo temperature.
+	/// \param[in] servoId ID of the servo
+	/// \return Temperature, in degC. 0 on failure.
+	int getCurrentTemperature(byte const &servoId);
 
-    /// \brief Get current servo current.
-    /// \param[in] servoId ID of the servo
-    /// \return Current, in A.
-    int getCurrentCurrent(byte const &servoId);
+	/// \brief Get current servo current.
+	/// \param[in] servoId ID of the servo
+	/// \return Current, in A.
+	int getCurrentCurrent(byte const &servoId);
 
-    /// \brief Check if the servo is moving
-    /// \param[in] servoId ID of the servo
-    /// \return True if moving, false otherwise.
-    bool isMoving(byte const &servoId);
+	/// \brief Check if the servo is moving
+	/// \param[in] servoId ID of the servo
+	/// \return True if moving, false otherwise.
+	bool isMoving(byte const &servoId);
 
-    /// \brief Set target servo position.
-    /// \note This function assumes that the amplification factor ANGULAR_RESOLUTION is set to 1.
-    /// \param[in] servoId ID of the servo
-    /// \param[in] position Target position, in counts.
-    /// \param[in] speed speed of the servo.
-    /// \param[in] asynchronous If set, write is asynchronous (ACTION must be send to activate)
-    /// \return True on success, false otherwise.
-    bool setTargetPosition(byte const &servoId, int const &position, int const &speed, bool const &asynchronous = false);
+	/// \brief Set target servo position.
+	/// \note This function assumes that the amplification factor ANGULAR_RESOLUTION is set to 1.
+	/// \param[in] servoId ID of the servo
+	/// \param[in] position Target position, in counts.
+	/// \param[in] speed speed of the servo.
+	/// \param[in] asynchronous If set, write is asynchronous (ACTION must be send to activate)
+	/// \return True on success, false otherwise.
+	bool setTargetPosition(byte const &servoId, int const &position, int const &speed, bool const &asynchronous = false);
 
-    /// \brief Set target servo velocity.
-    /// \note This function assumes that the amplification factor ANGULAR_RESOLUTION is set to 1.
-    /// \param[in] servoId ID of the servo
-    /// \param[in] velocity Target velocity, in counts/s.
-    /// \param[in] asynchronous If set, write is asynchronous (ACTION must be send to activate)
-    /// \return True on success, false otherwise.
-    bool setTargetVelocity(byte const &servoId, int const &velocity, bool const &asynchronous = false);
+	/// \brief Set target servo velocity.
+	/// \note This function assumes that the amplification factor ANGULAR_RESOLUTION is set to 1.
+	/// \param[in] servoId ID of the servo
+	/// \param[in] velocity Target velocity, in counts/s.
+	/// \param[in] asynchronous If set, write is asynchronous (ACTION must be send to activate)
+	/// \return True on success, false otherwise.
+	bool setTargetVelocity(byte const &servoId, int const &velocity, bool const &asynchronous = false);
 
-    /// \brief Trigger the action previously stored by an asynchronous write on all servos.
-    /// \return True on success
-    bool trigerAction();
+	/// \brief Trigger the action previously stored by an asynchronous write on all servos.
+	/// \return True on success
+	bool trigerAction();
 
-    /// \brief Write to a single byte register.
-    /// \param[in] servoId ID of the servo
-    /// \param[in] registerId Register id.
-    /// \param[in] value Register value.
-    /// \param[in] asynchronous If set, write is asynchronous (ACTION must be send to activate)
-    /// \return True if write was successful
-    bool writeRegister(byte const &servoId,
-                       byte const &registerId,
-                       byte const &value,
-                       bool const &asynchronous = false);
+	/// \brief Write to a single byte register.
+	/// \param[in] servoId ID of the servo
+	/// \param[in] registerId Register id.
+	/// \param[in] value Register value.
+	/// \param[in] asynchronous If set, write is asynchronous (ACTION must be send to activate)
+	/// \return True if write was successful
+	bool writeRegister(byte const &servoId,
+					   byte const &registerId,
+					   byte const &value,
+					   bool const &asynchronous = false);
 
-    /// \brief Write a two-bytes register.
-    /// \param[in] servoId ID of the servo
-    /// \param[in] registerId Register id (LSB).
-    /// \param[in] value Register value.
-    /// \param[in] asynchronous If set, write is asynchronous (ACTION must be send to activate)
-    /// \return True if write was successful
-    bool writeTwoBytesRegister(byte const &servoId,
-                               byte const &registerId,
-                               int16_t const &value,
-                               bool const &asynchronous = false);
+	/// \brief Write a two-bytes register.
+	/// \param[in] servoId ID of the servo
+	/// \param[in] registerId Register id (LSB).
+	/// \param[in] value Register value.
+	/// \param[in] asynchronous If set, write is asynchronous (ACTION must be send to activate)
+	/// \return True if write was successful
+	bool writeTwoBytesRegister(byte const &servoId,
+							   byte const &registerId,
+							   int16_t const &value,
+							   bool const &asynchronous = false);
 
-    /// \brief Read a single register
-    /// \param[in] servoId ID of the servo
-    /// \param[in] registerId Register id.
-    /// \return Register value, 0 on failure.
-    byte readRegister(byte const &servoId, byte const &registerId);
+	/// \brief Read a single register
+	/// \param[in] servoId ID of the servo
+	/// \param[in] registerId Register id.
+	/// \return Register value, 0 on failure.
+	byte readRegister(byte const &servoId, byte const &registerId);
 
-    /// \brief Read two bytes, interpret result as <LSB> <MSB>
-    /// \param[in] servoId ID of the servo
-    /// \param[in] registerId LSB register id.
-    /// \return Register value, 0 on failure.
-    int16_t readTwoBytesRegister(byte const &servoId, byte const &registerId);
+	/// \brief Read two bytes, interpret result as <LSB> <MSB>
+	/// \param[in] servoId ID of the servo
+	/// \param[in] registerId LSB register id.
+	/// \return Register value, 0 on failure.
+	int16_t readTwoBytesRegister(byte const &servoId, byte const &registerId);
 
-    /// @brief Sets the target positions for multiple servos simultaneously.
-    /// @param[in] servoIds Array of servo IDs to control.
-    /// @param[in] positions Array of target positions (corresponds to servoIds).
-    /// @param[in] speeds Array of target speeds (corresponds to servoIds).
-    void setTargetPositions(const byte servoIds[],
-                            const int positions[],
-                            const int speeds[]);
+	/// @brief Sets the target positions for multiple servos simultaneously.
+	/// @param[in] NumberOfServos Number of servo.
+	/// @param[in] servoIds Array of servo IDs to control.
+	/// @param[in] positions Array of target positions (corresponds to servoIds).
+	/// @param[in] speeds Array of target speeds (corresponds to servoIds).
+	void setTargetPositions(byte const &NumberOfServos,
+							const byte servoIds[],
+							const int positions[],
+							const int speeds[]);
 
 private:
-    /// \brief Clear internal device error.
-    // void clearError();
+	/// \brief Clear internal device error.
+	// void clearError();
 
-    /// \brief Send a message to the servos.
-    /// \param[in] servoId ID of the servo
-    /// \param[in] commandID Command id
-    /// \param[in] paramLength length of the parameters
-    /// \param[in] parameters parameters
-    /// \return Result of write.
-    int sendMessage(byte const &servoId,
-                    byte const &commandID,
-                    byte const &paramLength,
-                    byte *parameters);
+	/// \brief Send a message to the servos.
+	/// \param[in] servoId ID of the servo
+	/// \param[in] commandID Command id
+	/// \param[in] paramLength length of the parameters
+	/// \param[in] parameters parameters
+	/// \return Result of write.
+	int sendMessage(byte const &servoId,
+					byte const &commandID,
+					byte const &paramLength,
+					byte *parameters);
 
-    /// \brief Recieve a message from a given servo.
-    /// \param[in] servoId ID of the servo
-    /// \param[in] readLength Message length
-    /// \param[in] paramLength length of the parameters
-    /// \param[in] outputBuffer Buffer where the data is placed.
-    /// \return 0 on success
-    ///         -1 if read failed due to timeout
-    ///         -2 if invalid message (no 0XFF, wrong servo id)
-    ///         -3 if invalid checksum
-    int recieveMessage(byte const &servoId,
-                       byte const &readLength,
-                       byte *outputBuffer);
+	/// \brief Recieve a message from a given servo.
+	/// \param[in] servoId ID of the servo
+	/// \param[in] readLength Message length
+	/// \param[in] paramLength length of the parameters
+	/// \param[in] outputBuffer Buffer where the data is placed.
+	/// \return 0 on success
+	///         -1 if read failed due to timeout
+	///         -2 if invalid message (no 0XFF, wrong servo id)
+	///         -3 if invalid checksum
+	int recieveMessage(byte const &servoId,
+					   byte const &readLength,
+					   byte *outputBuffer);
 
-    /// \brief Write to a sequence of consecutive registers
-    /// \param[in] servoId ID of the servo
-    /// \param[in] startRegister First register
-    /// \param[in] writeLength Number of registers to write
-    /// \param[in] parameters Value of the registers
-    /// \param[in] asynchronous If set, write is asynchronous (ACTION must be send to activate)
-    /// \return True if write was successful
-    bool writeRegisters(byte const &servoId,
-                        byte const &startRegister,
-                        byte const &writeLength,
-                        byte const *parameters,
-                        bool const &asynchronous = false);
+	/// \brief Write to a sequence of consecutive registers
+	/// \param[in] servoId ID of the servo
+	/// \param[in] startRegister First register
+	/// \param[in] writeLength Number of registers to write
+	/// \param[in] parameters Value of the registers
+	/// \param[in] asynchronous If set, write is asynchronous (ACTION must be send to activate)
+	/// \return True if write was successful
+	bool writeRegisters(byte const &servoId,
+						byte const &startRegister,
+						byte const &writeLength,
+						byte const *parameters,
+						bool const &asynchronous = false);
 
-    /// \brief Read a sequence of consecutive registers.
-    /// \param[in] servoId ID of the servo
-    /// \param[in] startRegister First register
-    /// \param[in] readLength Number of registers to write
-    /// \param[out] outputBuffer Buffer where to read the data (must have been allocated by the user)
-    /// \return 0 on success, -1 if write failed, -2 if read failed, -3 if checksum verification failed
-    int readRegisters(byte const &servoId,
-                      byte const &startRegister,
-                      byte const &readLength,
-                      byte *outputBuffer);
+	/// \brief Read a sequence of consecutive registers.
+	/// \param[in] servoId ID of the servo
+	/// \param[in] startRegister First register
+	/// \param[in] readLength Number of registers to write
+	/// \param[out] outputBuffer Buffer where to read the data (must have been allocated by the user)
+	/// \return 0 on success, -1 if write failed, -2 if read failed, -3 if checksum verification failed
+	int readRegisters(byte const &servoId,
+					  byte const &startRegister,
+					  byte const &readLength,
+					  byte *outputBuffer);
 
-    /// @brief Send two bytes and update checksum
-    /// @param[in] convertedValue Converted int value
-    /// @param[out] checksum Update the checksum
-    void sendAndUpdateChecksum(byte convertedValue[], byte &checksum);
+	/// @brief Send two bytes and update checksum
+	/// @param[in] convertedValue Converted int value
+	/// @param[out] checksum Update the checksum
+	void sendAndUpdateChecksum(byte convertedValue[], byte &checksum);
 
-    /// @brief Convert int to pair of bytes
-    /// @param[in] value
-    /// @param[out] result
-    void convertIntToBytes(int const &value, byte result[2]);
+	/// @brief Convert int to pair of bytes
+	/// @param[in] value
+	/// @param[out] result
+	void convertIntToBytes(int const &value, byte result[2]);
 
-    HardwareSerial *port_;
-    byte dirPin_; ///< Direction pin number.
+	HardwareSerial *port_;
+	byte dirPin_; ///< Direction pin number.
 };
 #endif

--- a/src/STSServoDriver.h
+++ b/src/STSServoDriver.h
@@ -90,6 +90,12 @@ public:
 	/// \return True if servo could successfully change ID
 	bool setId(byte const &oldServoId, byte const &newServoId);
 
+	/// \brief Change the goal acceleration of a servo.
+	/// \param[in] servoId servo ID
+	/// \param[in] acceleration goal acceleration
+	/// \return True if servo could successfully set goal acceleration
+	bool setGoalAcceleration(byte const &servoId, byte const &acceleration)
+
 	/// \brief Get current servo position.
 	/// \note This function assumes that the amplification factor ANGULAR_RESOLUTION is set to 1.
 	/// \param[in] servoId ID of the servo


### PR DESCRIPTION
This pull request introduces a new 'sync move' function to the codebase, along with an accompanying usage example.

The 'sync move' function enhances our library by allowing users to synchronize the movement of multiple servos. This is particularly beneficial in scenarios where coordinated movement of servos is required.

The usage example provides a clear demonstration of how to use the 'sync move' function, which will aid users in correctly implementing this function in their projects.

Changes included:

1. Addition of the 'sync move' function in STSServoDriver.cpp and STSServoDriver.h.
2. Addition of a 'sync move' usage example in examples/syncMove/syncMove.ino.

I encourage reviewers to test the function using the provided example and offer feedback on the implementation. Any suggestions for improvements or optimizations are always welcome.

Thank you.
